### PR TITLE
Support >16 byte struct alignment, add double vec/matrix types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Crevice Changelog
 
 ## Unreleased Changes
+* Added f64-based std140 types: `DVec2`, `DVec3`, `DVec4`, `DMat2`, `DMat3`, and `DMat4`.
+* Added support for std140 structs with alignment greater than 16.
 
 ## 0.4.0 (2020-10-01)
 * Added `AsStd140::std140_size` for easily pre-sizing buffers.

--- a/crevice-derive/src/lib.rs
+++ b/crevice-derive/src/lib.rs
@@ -1,7 +1,8 @@
 use proc_macro::TokenStream as CompilerTokenStream;
 
+use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
-use syn::{parse_macro_input, Data, DeriveInput, Fields};
+use syn::{parse_macro_input, Data, DeriveInput, Fields, FieldsNamed};
 
 #[proc_macro_derive(AsStd140)]
 pub fn derive_as_std140(input: CompilerTokenStream) -> CompilerTokenStream {
@@ -75,15 +76,7 @@ pub fn derive_as_std140(input: CompilerTokenStream) -> CompilerTokenStream {
         initializer.push(quote!(#field_name: self.#field_name.as_std140()));
     }
 
-    let struct_alignment = fields.named.iter().fold(quote!(16usize), |last, field| {
-        let field_ty = &field.ty;
-        quote! {
-            ::crevice::internal::max(
-                <<#field_ty as ::crevice::std140::AsStd140>::Std140Type as ::crevice::std140::Std140>::ALIGNMENT,
-                #last,
-            )
-        }
-    });
+    let struct_alignment = emit_struct_alignment(16, fields);
 
     let type_layout_derive = if cfg!(feature = "test_type_layout") {
         quote!(#[derive(::type_layout::TypeLayout)])
@@ -129,4 +122,30 @@ pub fn derive_as_std140(input: CompilerTokenStream) -> CompilerTokenStream {
 
     // Hand the output tokens back to the compiler
     CompilerTokenStream::from(expanded)
+}
+
+/// Emit a const expression that computes the alignment of a struct based on its
+/// minimum alignment and fields.
+///
+/// The minimum alignment of an std140 struct is 16, while the minimum alignment
+/// for an std430 struct is 0.
+fn emit_struct_alignment(min_alignment: usize, fields: &FieldsNamed) -> TokenStream {
+    // This fold builds up an expression that finds the maximum alignment out of
+    // all of the fields in the struct. For this struct:
+    //
+    // struct Foo { a: ty1, b: ty2 }
+    //
+    // ...we should generate an expression like this:
+    //
+    // max(ty2_align, max(ty1_align, min_align))
+    fields.named.iter().fold(quote!(#min_alignment), |last, field| {
+        let field_ty = &field.ty;
+
+        quote! {
+            ::crevice::internal::max(
+                <<#field_ty as ::crevice::std140::AsStd140>::Std140Type as ::crevice::std140::Std140>::ALIGNMENT,
+                #last,
+            )
+        }
+    })
 }

--- a/src/std140/primitives.rs
+++ b/src/std140/primitives.rs
@@ -18,101 +18,109 @@ unsafe impl Std140 for u32 {
     const ALIGNMENT: usize = 4;
 }
 
-/// Corresponds to GLSL's `vec2`.
-#[allow(missing_docs)]
-#[derive(Debug, Clone, Copy)]
-pub struct Vec2 {
-    pub x: f32,
-    pub y: f32,
+macro_rules! vector {
+    ( $glsl_name:ident align($align:literal) $name:ident <$prim:ident> ($($field:ident),+) ) => {
+        vector!(
+            impl
+            $glsl_name $name <$prim> ($($field),+) align($align)
+            doc(concat!("Corresponds to GLSL's `", stringify!($glsl_name), "`."))
+        );
+    };
+
+    ( impl $glsl_name:ident $name:ident <$prim:ident> ($($field:ident),+) align($align:literal) doc($doc:expr) ) => {
+        #[doc = $doc]
+        #[allow(missing_docs)]
+        #[derive(Debug, Clone, Copy)]
+        pub struct $name {
+            $(pub $field: $prim,)+
+        }
+
+        unsafe impl Zeroable for $name {}
+        unsafe impl Pod for $name {}
+
+        unsafe impl Std140 for $name {
+            const ALIGNMENT: usize = $align;
+        }
+    };
 }
 
-unsafe impl Zeroable for Vec2 {}
-unsafe impl Pod for Vec2 {}
+vector!(vec2 align(8) Vec2<f32>(x, y));
+vector!(vec3 align(16) Vec3<f32>(x, y, z));
+vector!(vec4 align(16) Vec4<f32>(x, y, z, w));
 
-unsafe impl Std140 for Vec2 {
-    const ALIGNMENT: usize = 8;
+vector!(dvec2 align(16) DVec2<f64>(x, y));
+vector!(dvec3 align(32) DVec3<f64>(x, y, z));
+vector!(dvec4 align(32) DVec4<f64>(x, y, z, w));
+
+macro_rules! matrix {
+    ( $glsl_name: ident align($align:literal) $name: ident {
+        $($field:ident: $field_ty:ty,)+
+    }) => {
+        matrix!(
+            impl
+            doc(concat!("Corresponds to GLSL's `", stringify!($glsl_name), "`."))
+            $glsl_name align($align) $name {
+                $($field: $field_ty,)+
+            }
+        );
+    };
+
+    ( impl doc($doc:expr) $glsl_name: ident align($align:literal) $name: ident {
+        $($field:ident: $field_ty:ty,)+
+    }) => {
+        /// Corresponds to GLSL's `mat2`.
+        #[allow(missing_docs)]
+        #[derive(Debug, Clone, Copy)]
+        pub struct $name {
+            $(pub $field: $field_ty,)+
+        }
+
+        unsafe impl Zeroable for $name {}
+        unsafe impl Pod for $name {}
+
+        unsafe impl Std140 for $name {
+            const ALIGNMENT: usize = $align;
+        }
+    };
 }
 
-/// Corresponds to GLSL's `vec3`.
-#[allow(missing_docs)]
-#[derive(Debug, Clone, Copy)]
-pub struct Vec3 {
-    pub x: f32,
-    pub y: f32,
-    pub z: f32,
-}
+matrix!(mat2 align(16) Mat2 {
+    x: Vec2,
+    _pad_y: [f32; 2],
+    y: Vec2,
+});
 
-unsafe impl Zeroable for Vec3 {}
-unsafe impl Pod for Vec3 {}
+matrix!(mat3 align(16) Mat3 {
+    x: Vec3,
+    _pad_y: f32,
+    y: Vec3,
+    _pad_z: f32,
+    z: Vec3,
+});
 
-unsafe impl Std140 for Vec3 {
-    const ALIGNMENT: usize = 16;
-}
+matrix!(mat4 align(16) Mat4 {
+    x: Vec4,
+    y: Vec4,
+    z: Vec4,
+    w: Vec4,
+});
 
-/// Corresponds to GLSL's `vec4`.
-#[allow(missing_docs)]
-#[derive(Debug, Clone, Copy)]
-pub struct Vec4 {
-    pub x: f32,
-    pub y: f32,
-    pub z: f32,
-    pub w: f32,
-}
+matrix!(dmat2 align(16) DMat2 {
+    x: DVec2,
+    y: DVec2,
+});
 
-unsafe impl Zeroable for Vec4 {}
-unsafe impl Pod for Vec4 {}
+matrix!(dmat2 align(32) DMat3 {
+    x: DVec3,
+    _pad_x: f64,
+    y: DVec3,
+    _pad_y: f64,
+    z: DVec3,
+});
 
-unsafe impl Std140 for Vec4 {
-    const ALIGNMENT: usize = 16;
-}
-
-/// Corresponds to GLSL's `mat2`.
-#[allow(missing_docs)]
-#[derive(Debug, Clone, Copy)]
-pub struct Mat2 {
-    pub x: Vec2,
-    pub _pad_y: [f32; 2],
-    pub y: Vec2,
-}
-
-unsafe impl Zeroable for Mat2 {}
-unsafe impl Pod for Mat2 {}
-
-unsafe impl Std140 for Mat2 {
-    const ALIGNMENT: usize = 16;
-}
-
-/// Corresponds to GLSL's `mat3`.
-#[allow(missing_docs)]
-#[derive(Debug, Clone, Copy)]
-pub struct Mat3 {
-    pub x: Vec3,
-    pub _pad_y: f32,
-    pub y: Vec3,
-    pub _pad_z: f32,
-    pub z: Vec3,
-}
-
-unsafe impl Zeroable for Mat3 {}
-unsafe impl Pod for Mat3 {}
-
-unsafe impl Std140 for Mat3 {
-    const ALIGNMENT: usize = 16;
-}
-
-/// Corresponds to GLSL's `mat4`.
-#[allow(missing_docs)]
-#[derive(Debug, Clone, Copy)]
-pub struct Mat4 {
-    pub x: Vec4,
-    pub y: Vec4,
-    pub z: Vec4,
-    pub w: Vec4,
-}
-
-unsafe impl Zeroable for Mat4 {}
-unsafe impl Pod for Mat4 {}
-
-unsafe impl Std140 for Mat4 {
-    const ALIGNMENT: usize = 16;
-}
+matrix!(dmat3 align(32) DMat4 {
+    x: DVec4,
+    y: DVec4,
+    z: DVec4,
+    w: DVec4,
+});

--- a/src/std140/primitives.rs
+++ b/src/std140/primitives.rs
@@ -18,109 +18,119 @@ unsafe impl Std140 for u32 {
     const ALIGNMENT: usize = 4;
 }
 
-macro_rules! vector {
-    ( $glsl_name:ident align($align:literal) $name:ident <$prim:ident> ($($field:ident),+) ) => {
-        vector!(
-            impl
-            $glsl_name $name <$prim> ($($field),+) align($align)
-            doc(concat!("Corresponds to GLSL's `", stringify!($glsl_name), "`."))
-        );
-    };
-
-    ( impl $glsl_name:ident $name:ident <$prim:ident> ($($field:ident),+) align($align:literal) doc($doc:expr) ) => {
-        #[doc = $doc]
-        #[allow(missing_docs)]
-        #[derive(Debug, Clone, Copy)]
-        pub struct $name {
-            $(pub $field: $prim,)+
-        }
-
-        unsafe impl Zeroable for $name {}
-        unsafe impl Pod for $name {}
-
-        unsafe impl Std140 for $name {
-            const ALIGNMENT: usize = $align;
-        }
-    };
-}
-
-vector!(vec2 align(8) Vec2<f32>(x, y));
-vector!(vec3 align(16) Vec3<f32>(x, y, z));
-vector!(vec4 align(16) Vec4<f32>(x, y, z, w));
-
-vector!(dvec2 align(16) DVec2<f64>(x, y));
-vector!(dvec3 align(32) DVec3<f64>(x, y, z));
-vector!(dvec4 align(32) DVec4<f64>(x, y, z, w));
-
-macro_rules! matrix {
-    ( $glsl_name: ident align($align:literal) $name: ident {
-        $($field:ident: $field_ty:ty,)+
-    }) => {
-        matrix!(
-            impl
-            doc(concat!("Corresponds to GLSL's `", stringify!($glsl_name), "`."))
-            $glsl_name align($align) $name {
-                $($field: $field_ty,)+
+macro_rules! vectors {
+    (
+        $(
+            #[$doc:meta] align($align:literal) $name:ident <$prim:ident> ($($field:ident),+)
+        )+
+    ) => {
+        $(
+            #[$doc]
+            #[allow(missing_docs)]
+            #[derive(Debug, Clone, Copy)]
+            pub struct $name {
+                $(pub $field: $prim,)+
             }
-        );
-    };
 
-    ( impl doc($doc:expr) $glsl_name: ident align($align:literal) $name: ident {
-        $($field:ident: $field_ty:ty,)+
-    }) => {
-        /// Corresponds to GLSL's `mat2`.
-        #[allow(missing_docs)]
-        #[derive(Debug, Clone, Copy)]
-        pub struct $name {
-            $(pub $field: $field_ty,)+
-        }
+            unsafe impl Zeroable for $name {}
+            unsafe impl Pod for $name {}
 
-        unsafe impl Zeroable for $name {}
-        unsafe impl Pod for $name {}
-
-        unsafe impl Std140 for $name {
-            const ALIGNMENT: usize = $align;
-        }
+            unsafe impl Std140 for $name {
+                const ALIGNMENT: usize = $align;
+            }
+        )+
     };
 }
 
-matrix!(mat2 align(16) Mat2 {
-    x: Vec2,
-    _pad_y: [f32; 2],
-    y: Vec2,
-});
+vectors! {
+    #[doc = "Corresponds to GLSL's `vec2`."] align(8) Vec2<f32>(x, y)
+    #[doc = "Corresponds to GLSL's `vec3`."] align(16) Vec3<f32>(x, y, z)
+    #[doc = "Corresponds to GLSL's `vec4`."] align(16) Vec4<f32>(x, y, z, w)
 
-matrix!(mat3 align(16) Mat3 {
-    x: Vec3,
-    _pad_y: f32,
-    y: Vec3,
-    _pad_z: f32,
-    z: Vec3,
-});
+    #[doc = "Corresponds to GLSL's `dvec2`."] align(16) DVec2<f64>(x, y)
+    #[doc = "Corresponds to GLSL's `dvec3`."] align(32) DVec3<f64>(x, y, z)
+    #[doc = "Corresponds to GLSL's `dvec4`."] align(32) DVec4<f64>(x, y, z, w)
+}
 
-matrix!(mat4 align(16) Mat4 {
-    x: Vec4,
-    y: Vec4,
-    z: Vec4,
-    w: Vec4,
-});
+macro_rules! matrices {
+    (
+        $(
+            #[$doc:meta]
+            align($align:literal)
+            $name:ident {
+                $($field:ident: $field_ty:ty,)+
+            }
+        )+
+    ) => {
+        $(
+            #[$doc]
+            #[allow(missing_docs)]
+            #[derive(Debug, Clone, Copy)]
+            pub struct $name {
+                $(pub $field: $field_ty,)+
+            }
 
-matrix!(dmat2 align(16) DMat2 {
-    x: DVec2,
-    y: DVec2,
-});
+            unsafe impl Zeroable for $name {}
+            unsafe impl Pod for $name {}
 
-matrix!(dmat2 align(32) DMat3 {
-    x: DVec3,
-    _pad_x: f64,
-    y: DVec3,
-    _pad_y: f64,
-    z: DVec3,
-});
+            unsafe impl Std140 for $name {
+                const ALIGNMENT: usize = $align;
+            }
+        )+
+    };
+}
 
-matrix!(dmat3 align(32) DMat4 {
-    x: DVec4,
-    y: DVec4,
-    z: DVec4,
-    w: DVec4,
-});
+matrices! {
+    #[doc = "Corresponds to GLSL's `mat2`."]
+    align(16)
+    Mat2 {
+        x: Vec2,
+        _pad_y: [f32; 2],
+        y: Vec2,
+    }
+
+    #[doc = "Corresponds to GLSL's `mat3`."]
+    align(16)
+    Mat3 {
+        x: Vec3,
+        _pad_y: f32,
+        y: Vec3,
+        _pad_z: f32,
+        z: Vec3,
+    }
+
+    #[doc = "Corresponds to GLSL's `mat4`."]
+    align(16)
+    Mat4 {
+        x: Vec4,
+        y: Vec4,
+        z: Vec4,
+        w: Vec4,
+    }
+
+    #[doc = "Corresponds to GLSL's `dmat2`."]
+    align(16)
+    DMat2 {
+        x: DVec2,
+        y: DVec2,
+    }
+
+    #[doc = "Corresponds to GLSL's `dmat2`."]
+    align(32)
+    DMat3 {
+        x: DVec3,
+        _pad_x: f64,
+        y: DVec3,
+        _pad_y: f64,
+        z: DVec3,
+    }
+
+    #[doc = "Corresponds to GLSL's `dmat3`."]
+    align(32)
+    DMat4 {
+        x: DVec4,
+        y: DVec4,
+        z: DVec4,
+        w: DVec4,
+    }
+}

--- a/src/std140/primitives.rs
+++ b/src/std140/primitives.rs
@@ -43,13 +43,13 @@ macro_rules! vectors {
 }
 
 vectors! {
-    #[doc = "Corresponds to GLSL's `vec2`."] align(8) Vec2<f32>(x, y)
-    #[doc = "Corresponds to GLSL's `vec3`."] align(16) Vec3<f32>(x, y, z)
-    #[doc = "Corresponds to GLSL's `vec4`."] align(16) Vec4<f32>(x, y, z, w)
+    #[doc = "Corresponds to a GLSL `vec2` in std140 layout."] align(8) Vec2<f32>(x, y)
+    #[doc = "Corresponds to a GLSL `vec3` in std140 layout."] align(16) Vec3<f32>(x, y, z)
+    #[doc = "Corresponds to a GLSL `vec4` in std140 layout."] align(16) Vec4<f32>(x, y, z, w)
 
-    #[doc = "Corresponds to GLSL's `dvec2`."] align(16) DVec2<f64>(x, y)
-    #[doc = "Corresponds to GLSL's `dvec3`."] align(32) DVec3<f64>(x, y, z)
-    #[doc = "Corresponds to GLSL's `dvec4`."] align(32) DVec4<f64>(x, y, z, w)
+    #[doc = "Corresponds to a GLSL `dvec2` in std140 layout."] align(16) DVec2<f64>(x, y)
+    #[doc = "Corresponds to a GLSL `dvec3` in std140 layout."] align(32) DVec3<f64>(x, y, z)
+    #[doc = "Corresponds to a GLSL `dvec4` in std140 layout."] align(32) DVec4<f64>(x, y, z, w)
 }
 
 macro_rules! matrices {
@@ -81,25 +81,27 @@ macro_rules! matrices {
 }
 
 matrices! {
-    #[doc = "Corresponds to GLSL's `mat2`."]
+    #[doc = "Corresponds to a GLSL `mat2` in std140 layout."]
     align(16)
     Mat2 {
         x: Vec2,
-        _pad_y: [f32; 2],
+        _pad_x: [f32; 2],
         y: Vec2,
+        _pad_y: [f32; 2],
     }
 
-    #[doc = "Corresponds to GLSL's `mat3`."]
+    #[doc = "Corresponds to a GLSL `mat3` in std140 layout."]
     align(16)
     Mat3 {
         x: Vec3,
-        _pad_y: f32,
+        _pad_x: f32,
         y: Vec3,
-        _pad_z: f32,
+        _pad_y: f32,
         z: Vec3,
+        _pad_z: f32,
     }
 
-    #[doc = "Corresponds to GLSL's `mat4`."]
+    #[doc = "Corresponds to a GLSL `mat4` in std140 layout."]
     align(16)
     Mat4 {
         x: Vec4,
@@ -108,14 +110,14 @@ matrices! {
         w: Vec4,
     }
 
-    #[doc = "Corresponds to GLSL's `dmat2`."]
+    #[doc = "Corresponds to a GLSL `dmat2` in std140 layout."]
     align(16)
     DMat2 {
         x: DVec2,
         y: DVec2,
     }
 
-    #[doc = "Corresponds to GLSL's `dmat2`."]
+    #[doc = "Corresponds to a GLSL `dmat3` in std140 layout."]
     align(32)
     DMat3 {
         x: DVec3,
@@ -123,9 +125,10 @@ matrices! {
         y: DVec3,
         _pad_y: f64,
         z: DVec3,
+        _pad_z: f64,
     }
 
-    #[doc = "Corresponds to GLSL's `dmat3`."]
+    #[doc = "Corresponds to a GLSL `dmat3` in std140 layout."]
     align(32)
     DMat4 {
         x: DVec4,

--- a/tests/snapshots/std140__more_than_16_alignment.snap
+++ b/tests/snapshots/std140__more_than_16_alignment.snap
@@ -1,0 +1,16 @@
+---
+source: tests/std140.rs
+expression: "<<MoreThan16Alignment as AsStd140>::Std140Type as TypeLayout>::type_layout()"
+---
+name: Std140MoreThan16Alignment
+size: 32
+alignment: 8
+fields:
+  - Field:
+      name: _doubles_align
+      ty: "[u8 ; Std140MoreThan16AlignmentAlignment :: _doubles_align()]"
+      size: 0
+  - Field:
+      name: doubles
+      ty: "< DVec4 as :: crevice :: std140 :: AsStd140 > :: Std140Type"
+      size: 32

--- a/tests/std140.rs
+++ b/tests/std140.rs
@@ -1,7 +1,7 @@
 use insta::assert_yaml_snapshot;
 use type_layout::TypeLayout;
 
-use crevice::std140::{AsStd140, Vec3};
+use crevice::std140::{AsStd140, DVec4, Std140, Vec3};
 
 #[derive(AsStd140)]
 struct PrimitiveF32 {
@@ -12,6 +12,8 @@ struct PrimitiveF32 {
 #[test]
 fn primitive_f32() {
     assert_yaml_snapshot!(<<PrimitiveF32 as AsStd140>::Std140Type as TypeLayout>::type_layout());
+
+    assert_eq!(<PrimitiveF32 as AsStd140>::Std140Type::ALIGNMENT, 16);
 
     let value = PrimitiveF32 { x: 1.0, y: 2.0 };
     let _value_std140 = value.as_std140();
@@ -26,6 +28,8 @@ struct TestVec3 {
 #[test]
 fn test_vec3() {
     assert_yaml_snapshot!(<<TestVec3 as AsStd140>::Std140Type as TypeLayout>::type_layout());
+
+    assert_eq!(<TestVec3 as AsStd140>::Std140Type::ALIGNMENT, 16);
 
     let value = TestVec3 {
         pos: Vec3 {
@@ -54,6 +58,8 @@ fn using_vec3_padding() {
         <<UsingVec3Padding as AsStd140>::Std140Type as TypeLayout>::type_layout()
     );
 
+    assert_eq!(<UsingVec3Padding as AsStd140>::Std140Type::ALIGNMENT, 16);
+
     let value = UsingVec3Padding {
         pos: Vec3 {
             x: 1.0,
@@ -77,6 +83,8 @@ struct PointLight {
 fn point_light() {
     assert_yaml_snapshot!(<<PointLight as AsStd140>::Std140Type as TypeLayout>::type_layout());
 
+    assert_eq!(<PointLight as AsStd140>::Std140Type::ALIGNMENT, 16);
+
     let value = PointLight {
         position: Vec3 {
             x: 1.0,
@@ -96,4 +104,18 @@ fn point_light() {
         brightness: 4.0,
     };
     let _value_std140 = value.as_std140();
+}
+
+#[derive(AsStd140)]
+struct MoreThan16Alignment {
+    doubles: DVec4,
+}
+
+#[test]
+fn more_than_16_alignment() {
+    assert_yaml_snapshot!(
+        <<MoreThan16Alignment as AsStd140>::Std140Type as TypeLayout>::type_layout()
+    );
+
+    assert_eq!(<MoreThan16Alignment as AsStd140>::Std140Type::ALIGNMENT, 32);
 }


### PR DESCRIPTION
Closes #4.

This PR does a couple things that are intertwined. I'll try to explain each thing and why it's tangled with the others!

First, I added support for structs with alignment over 16 bytes. Thanks to @benmkw in [this comment](https://github.com/LPGhatguy/crevice/issues/1#issuecomment-711087465) for pointing out this need!

In order to write sufficient tests for that increased alignment, I needed base types with alignment greater than 16. Instead of adding fake types, I added the double types that we already wanted anyways. I'm not 100% sure about the layout of the double-based matrix types and would love some extra review.

In order to add the new vector and matrix types, I decided it was probably time to switch the vector and matrix declarations to use a macro. I figure this will be useful as part of #3 as well in the future, as well as if/when we introduce the int and bool-based vectors and matrices.