### PR TITLE
Add Std430 and refactor macro heavily

### DIFF
--- a/crevice-derive/src/lib.rs
+++ b/crevice-derive/src/lib.rs
@@ -1,151 +1,260 @@
 use proc_macro::TokenStream as CompilerTokenStream;
 
-use proc_macro2::TokenStream;
+use proc_macro2::{Span, TokenStream};
 use quote::{format_ident, quote};
-use syn::{parse_macro_input, Data, DeriveInput, Fields, FieldsNamed};
+use syn::{parse_macro_input, parse_quote, Data, DeriveInput, Fields, FieldsNamed, Ident, Path};
 
 #[proc_macro_derive(AsStd140)]
 pub fn derive_as_std140(input: CompilerTokenStream) -> CompilerTokenStream {
     let input = parse_macro_input!(input as DeriveInput);
+    let expanded = EmitOptions::new("Std140", "std140", 16).emit(input);
 
-    let visibility = input.vis;
-
-    let name = input.ident;
-    let std140_name = format_ident!("Std140{}", name);
-    let alignment_mod_name = format_ident!("Std140{}Alignment", name);
-
-    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
-
-    let fields = match &input.data {
-        Data::Struct(data) => match &data.fields {
-            Fields::Named(fields) => fields,
-            Fields::Unnamed(_) => panic!("Tuple structs are not supported"),
-            Fields::Unit => panic!("Unit structs are not supported"),
-        },
-        Data::Enum(_) | Data::Union(_) => panic!("Only structs are supported"),
-    };
-
-    let mut alignment_calculators = Vec::new();
-    let mut std140_fields = Vec::new();
-    let mut initializer = Vec::new();
-
-    let align_names: Vec<_> = fields
-        .named
-        .iter()
-        .map(|field| format_ident!("_{}_align", field.ident.as_ref().unwrap()))
-        .collect();
-
-    for (index, field) in fields.named.iter().enumerate() {
-        let field_name = field.ident.as_ref().unwrap();
-        let field_ty = &field.ty;
-
-        let align_name = &align_names[index];
-
-        let offset_accumulation =
-            fields
-                .named
-                .iter()
-                .enumerate()
-                .take(index)
-                .map(|(index, field)| {
-                    let ty = &field.ty;
-                    let align_name = &align_names[index];
-                    quote! {
-                        offset += #align_name();
-                        offset += ::std::mem::size_of::<#ty>();
-                    }
-                });
-
-        alignment_calculators.push(quote! {
-            pub const fn #align_name() -> usize {
-                let mut offset = 0;
-                #( #offset_accumulation )*
-
-                ::crevice::internal::align_offset(
-                    offset,
-                    <<#field_ty as ::crevice::std140::AsStd140>::Std140Type as ::crevice::std140::Std140>::ALIGNMENT
-                )
-            }
-        });
-
-        std140_fields.push(quote! {
-            #align_name: [u8; #alignment_mod_name::#align_name()],
-            #field_name: <#field_ty as ::crevice::std140::AsStd140>::Std140Type,
-        });
-
-        initializer.push(quote!(#field_name: self.#field_name.as_std140()));
-    }
-
-    let struct_alignment = emit_struct_alignment(16, fields);
-
-    let type_layout_derive = if cfg!(feature = "test_type_layout") {
-        quote!(#[derive(::type_layout::TypeLayout)])
-    } else {
-        quote!()
-    };
-
-    // Build the output, possibly using quasi-quotation
-    let expanded = quote! {
-        #[allow(non_snake_case)]
-        mod #alignment_mod_name {
-            use super::*;
-
-            #( #alignment_calculators )*
-        }
-
-        #[derive(Debug, Clone, Copy)]
-        #type_layout_derive
-        #[repr(C)]
-        #visibility struct #std140_name #ty_generics #where_clause {
-            #( #std140_fields )*
-        }
-
-        unsafe impl #impl_generics ::crevice::internal::bytemuck::Zeroable for #std140_name #ty_generics #where_clause {}
-        unsafe impl #impl_generics ::crevice::internal::bytemuck::Pod for #std140_name #ty_generics #where_clause {}
-
-        unsafe impl #impl_generics ::crevice::std140::Std140 for #std140_name #ty_generics #where_clause {
-            const ALIGNMENT: usize = #struct_alignment;
-        }
-
-        impl #impl_generics ::crevice::std140::AsStd140 for #name #ty_generics #where_clause {
-            type Std140Type = #std140_name;
-
-            fn as_std140(&self) -> Self::Std140Type {
-                Self::Std140Type {
-                    #( #initializer, )*
-
-                    ..::crevice::internal::bytemuck::Zeroable::zeroed()
-                }
-            }
-        }
-    };
-
-    // Hand the output tokens back to the compiler
     CompilerTokenStream::from(expanded)
 }
 
-/// Emit a const expression that computes the alignment of a struct based on its
-/// minimum alignment and fields.
-///
-/// The minimum alignment of an std140 struct is 16, while the minimum alignment
-/// for an std430 struct is 0.
-fn emit_struct_alignment(min_alignment: usize, fields: &FieldsNamed) -> TokenStream {
-    // This fold builds up an expression that finds the maximum alignment out of
-    // all of the fields in the struct. For this struct:
-    //
-    // struct Foo { a: ty1, b: ty2 }
-    //
-    // ...we should generate an expression like this:
-    //
-    // max(ty2_align, max(ty1_align, min_align))
-    fields.named.iter().fold(quote!(#min_alignment), |last, field| {
-        let field_ty = &field.ty;
+#[proc_macro_derive(AsStd430)]
+pub fn derive_as_std430(input: CompilerTokenStream) -> CompilerTokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let expanded = EmitOptions::new("Std430", "std430", 0).emit(input);
+
+    CompilerTokenStream::from(expanded)
+}
+
+struct EmitOptions {
+    /// The Rust-friendly name of the layout, like Std140.
+    layout_name: Ident,
+
+    /// The minimum alignment for a struct in this layout.
+    min_struct_alignment: usize,
+
+    /// The fully-qualified path to the Crevice module containing everything for
+    /// this layout.
+    mod_path: Path,
+
+    /// The fully-qualified path to the trait defining a type in this layout.
+    trait_path: Path,
+
+    /// The fully-qualified path to the trait implemented for types that can be
+    /// converted into this layout, like AsStd140.
+    as_trait_path: Path,
+
+    /// The name of the associated type contained in AsTrait.
+    as_trait_assoc: Ident,
+
+    /// The name of the method used to convert from AsTrait to Trait.
+    as_trait_method: Ident,
+}
+
+impl EmitOptions {
+    fn new(layout_name: &'static str, mod_name: &'static str, min_struct_alignment: usize) -> Self {
+        let mod_name = Ident::new(mod_name, Span::call_site());
+        let layout_name = Ident::new(layout_name, Span::call_site());
+
+        let mod_path = parse_quote!(::crevice::#mod_name);
+        let trait_path = parse_quote!(#mod_path::#layout_name);
+
+        let as_trait_name = format_ident!("As{}", layout_name);
+        let as_trait_path = parse_quote!(#mod_path::#as_trait_name);
+        let as_trait_assoc = format_ident!("{}Type", layout_name);
+        let as_trait_method = format_ident!("as_{}", mod_name);
+
+        Self {
+            layout_name,
+            min_struct_alignment,
+
+            mod_path,
+            trait_path,
+            as_trait_path,
+            as_trait_assoc,
+            as_trait_method,
+        }
+    }
+
+    fn emit(&self, input: DeriveInput) -> TokenStream {
+        let layout_name = &self.layout_name;
+        let mod_path = &self.mod_path;
+        let as_trait_path = &self.as_trait_path;
+        let as_trait_assoc = &self.as_trait_assoc;
+        let as_trait_method = &self.as_trait_method;
+
+        let visibility = input.vis;
+
+        let name = input.ident;
+        let generated_name = format_ident!("{}{}", layout_name, name);
+        let alignment_mod_name = format_ident!("{}{}Alignment", layout_name, name);
+
+        let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+        let fields = match &input.data {
+            Data::Struct(data) => match &data.fields {
+                Fields::Named(fields) => fields,
+                Fields::Unnamed(_) => panic!("Tuple structs are not supported"),
+                Fields::Unit => panic!("Unit structs are not supported"),
+            },
+            Data::Enum(_) | Data::Union(_) => panic!("Only structs are supported"),
+        };
+
+        // Generate the names we'll use for calculating alignment of each field.
+        // Each name will turn into a const fn that's invoked to compute the
+        // size of a padding array before each field.
+        let align_names: Vec<_> = fields
+            .named
+            .iter()
+            .map(|field| format_ident!("_{}_align", field.ident.as_ref().unwrap()))
+            .collect();
+
+        // Generate one function per field that is used to apply alignment
+        // padding. Each function invokes all previous functions to calculate
+        // the total offset into the struct for the current field, then aligns
+        // up to the nearest multiple of alignment.
+        let alignment_calculators: Vec<_> = fields
+            .named
+            .iter()
+            .enumerate()
+            .map(|(index, field)| {
+                let align_name = &align_names[index];
+
+                let offset_accumulation =
+                    fields
+                        .named
+                        .iter()
+                        .zip(&align_names)
+                        .take(index)
+                        .map(|(field, align_name)| {
+                            let field_ty = &field.ty;
+                            quote! {
+                                offset += #align_name();
+                                offset += ::std::mem::size_of::<#field_ty>();
+                            }
+                        });
+
+                let field_ty = &field.ty;
+
+                quote! {
+                    pub const fn #align_name() -> usize {
+                        let mut offset = 0;
+                        #( #offset_accumulation )*
+
+                        ::crevice::internal::align_offset(
+                            offset,
+                            <<#field_ty as #as_trait_path>::#as_trait_assoc as #mod_path::#layout_name>::ALIGNMENT
+                        )
+                    }
+                }
+            })
+            .collect();
+
+        // Generate the struct fields that will be present in the generated
+        // struct. Each field in the original struct turns into two fields in
+        // the generated struct:
+        //
+        // * Alignment, a byte array whose size is computed from #align_name().
+        // * Data, the layout-specific version of the original field.
+        let generated_fields: Vec<_> = fields
+            .named
+            .iter()
+            .zip(&align_names)
+            .map(|(field, align_name)| {
+                let field_ty = &field.ty;
+                let field_name = field.ident.as_ref().unwrap();
+
+                quote! {
+                    #align_name: [u8; #alignment_mod_name::#align_name()],
+                    #field_name: <#field_ty as #as_trait_path>::#as_trait_assoc,
+                }
+            })
+            .collect();
+
+        // Generate an initializer for each field in the original struct.
+        // Alignment fields are filled in with zeroes using struct update
+        // syntax.
+        let field_initializers: Vec<_> = fields
+            .named
+            .iter()
+            .map(|field| {
+                let field_name = field.ident.as_ref().unwrap();
+
+                quote!(#field_name: self.#field_name.#as_trait_method())
+            })
+            .collect();
+
+        let struct_alignment = self.emit_struct_alignment(fields);
+
+        // For testing purposes, we can optionally generate type layout
+        // information using the type-layout crate.
+        let type_layout_derive = if cfg!(feature = "test_type_layout") {
+            quote!(#[derive(::type_layout::TypeLayout)])
+        } else {
+            quote!()
+        };
 
         quote! {
-            ::crevice::internal::max(
-                <<#field_ty as ::crevice::std140::AsStd140>::Std140Type as ::crevice::std140::Std140>::ALIGNMENT,
-                #last,
-            )
+            #[allow(non_snake_case)]
+            mod #alignment_mod_name {
+                use super::*;
+
+                #( #alignment_calculators )*
+            }
+
+            #[derive(Debug, Clone, Copy)]
+            #type_layout_derive
+            #[repr(C)]
+            #visibility struct #generated_name #ty_generics #where_clause {
+                #( #generated_fields )*
+            }
+
+            unsafe impl #impl_generics ::crevice::internal::bytemuck::Zeroable for #generated_name #ty_generics #where_clause {}
+            unsafe impl #impl_generics ::crevice::internal::bytemuck::Pod for #generated_name #ty_generics #where_clause {}
+
+            unsafe impl #impl_generics #mod_path::#layout_name for #generated_name #ty_generics #where_clause {
+                const ALIGNMENT: usize = #struct_alignment;
+            }
+
+            impl #impl_generics #as_trait_path for #name #ty_generics #where_clause {
+                type #as_trait_assoc = #generated_name;
+
+                fn #as_trait_method(&self) -> Self::#as_trait_assoc {
+                    Self::#as_trait_assoc {
+                        #( #field_initializers, )*
+
+                        ..::crevice::internal::bytemuck::Zeroable::zeroed()
+                    }
+                }
+            }
         }
-    })
+    }
+
+    /// Emit a const expression that computes the alignment of a struct based on its
+    /// minimum alignment and fields.
+    ///
+    /// The minimum alignment of an std140 struct is 16, while the minimum alignment
+    /// for an std430 struct is 0.
+    fn emit_struct_alignment(&self, fields: &FieldsNamed) -> TokenStream {
+        let min_alignment = self.min_struct_alignment;
+        let trait_path = &self.trait_path;
+        let as_trait_path = &self.as_trait_path;
+        let as_trait_assoc = &self.as_trait_assoc;
+
+        // This fold builds up an expression that finds the maximum alignment out of
+        // all of the fields in the struct. For this struct:
+        //
+        // struct Foo { a: ty1, b: ty2 }
+        //
+        // ...we should generate an expression like this:
+        //
+        // max(ty2_align, max(ty1_align, min_align))
+        fields
+            .named
+            .iter()
+            .fold(quote!(#min_alignment), |last, field| {
+                let field_ty = &field.ty;
+
+                quote! {
+                    ::crevice::internal::max(
+                        <<#field_ty as #as_trait_path>::#as_trait_assoc as #trait_path>::ALIGNMENT,
+                        #last,
+                    )
+                }
+            })
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,6 +134,7 @@ Crevice supports Rust 1.46.0 and newer due to use of new `const fn` features.
 #![deny(missing_docs)]
 
 pub mod std140;
+pub mod std430;
 
 #[doc(hidden)]
 pub mod internal;

--- a/src/mint.rs
+++ b/src/mint.rs
@@ -4,33 +4,33 @@ use crate::std140::{self, AsStd140};
 use crate::std430::{self, AsStd430};
 
 macro_rules! mint_vectors {
-	( $( $mint_ty:ty, $std_name:ident, ( $($field:ident),* ), )* ) => {
-		$(
-			impl AsStd140 for $mint_ty {
-				type Std140Type = std140::$std_name;
+    ( $( $mint_ty:ty, $std_name:ident, ( $($field:ident),* ), )* ) => {
+        $(
+            impl AsStd140 for $mint_ty {
+                type Std140Type = std140::$std_name;
 
-				fn as_std140(&self) -> Self::Std140Type {
-					std140::$std_name {
-						$(
-							$field: self.$field,
-						)*
-					}
-				}
-			}
+                fn as_std140(&self) -> Self::Std140Type {
+                    std140::$std_name {
+                        $(
+                            $field: self.$field,
+                        )*
+                    }
+                }
+            }
 
-			impl AsStd430 for $mint_ty {
-				type Std430Type = std430::$std_name;
+            impl AsStd430 for $mint_ty {
+                type Std430Type = std430::$std_name;
 
-				fn as_std430(&self) -> Self::Std430Type {
-					std430::$std_name {
-						$(
-							$field: self.$field,
-						)*
-					}
-				}
-			}
-		)*
-	};
+                fn as_std430(&self) -> Self::Std430Type {
+                    std430::$std_name {
+                        $(
+                            $field: self.$field,
+                        )*
+                    }
+                }
+            }
+        )*
+    };
 }
 
 mint_vectors! {
@@ -40,35 +40,35 @@ mint_vectors! {
 }
 
 macro_rules! mint_matrices {
-	( $( $mint_ty:ty, $std_name:ident, ( $($field:ident),* ), )* ) => {
-		$(
-			impl AsStd140 for $mint_ty {
-				type Std140Type = std140::$std_name;
+    ( $( $mint_ty:ty, $std_name:ident, ( $($field:ident),* ), )* ) => {
+        $(
+            impl AsStd140 for $mint_ty {
+                type Std140Type = std140::$std_name;
 
-				fn as_std140(&self) -> Self::Std140Type {
-					std140::$std_name {
-						$(
-							$field: self.$field.as_std140(),
-						)*
-						..Zeroable::zeroed()
-					}
-				}
-			}
+                fn as_std140(&self) -> Self::Std140Type {
+                    std140::$std_name {
+                        $(
+                            $field: self.$field.as_std140(),
+                        )*
+                        ..Zeroable::zeroed()
+                    }
+                }
+            }
 
-			impl AsStd430 for $mint_ty {
-				type Std430Type = std430::$std_name;
+            impl AsStd430 for $mint_ty {
+                type Std430Type = std430::$std_name;
 
-				fn as_std430(&self) -> Self::Std430Type {
-					std430::$std_name {
-						$(
-							$field: self.$field.as_std430(),
-						)*
-						..Zeroable::zeroed()
-					}
-				}
-			}
-		)*
-	};
+                fn as_std430(&self) -> Self::Std430Type {
+                    std430::$std_name {
+                        $(
+                            $field: self.$field.as_std430(),
+                        )*
+                        ..Zeroable::zeroed()
+                    }
+                }
+            }
+        )*
+    };
 }
 
 mint_matrices! {

--- a/src/mint.rs
+++ b/src/mint.rs
@@ -1,77 +1,78 @@
 use bytemuck::Zeroable;
 
 use crate::std140::{self, AsStd140};
+use crate::std430::{self, AsStd430};
 
-impl AsStd140 for mint::Vector2<f32> {
-    type Std140Type = std140::Vec2;
+macro_rules! mint_vectors {
+	( $( $mint_ty:ty, $std_name:ident, ( $($field:ident),* ), )* ) => {
+		$(
+			impl AsStd140 for $mint_ty {
+				type Std140Type = std140::$std_name;
 
-    fn as_std140(&self) -> Self::Std140Type {
-        std140::Vec2 {
-            x: self.x,
-            y: self.y,
-        }
-    }
+				fn as_std140(&self) -> Self::Std140Type {
+					std140::$std_name {
+						$(
+							$field: self.$field,
+						)*
+					}
+				}
+			}
+
+			impl AsStd430 for $mint_ty {
+				type Std430Type = std430::$std_name;
+
+				fn as_std430(&self) -> Self::Std430Type {
+					std430::$std_name {
+						$(
+							$field: self.$field,
+						)*
+					}
+				}
+			}
+		)*
+	};
 }
 
-impl AsStd140 for mint::Vector3<f32> {
-    type Std140Type = std140::Vec3;
-
-    fn as_std140(&self) -> Self::Std140Type {
-        std140::Vec3 {
-            x: self.x,
-            y: self.y,
-            z: self.z,
-        }
-    }
+mint_vectors! {
+    mint::Vector2<f32>, Vec2, (x, y),
+    mint::Vector3<f32>, Vec3, (x, y, z),
+    mint::Vector4<f32>, Vec4, (x, y, z, w),
 }
 
-impl AsStd140 for mint::Vector4<f32> {
-    type Std140Type = std140::Vec4;
+macro_rules! mint_matrices {
+	( $( $mint_ty:ty, $std_name:ident, ( $($field:ident),* ), )* ) => {
+		$(
+			impl AsStd140 for $mint_ty {
+				type Std140Type = std140::$std_name;
 
-    fn as_std140(&self) -> Self::Std140Type {
-        std140::Vec4 {
-            x: self.x,
-            y: self.y,
-            z: self.z,
-            w: self.w,
-        }
-    }
+				fn as_std140(&self) -> Self::Std140Type {
+					std140::$std_name {
+						$(
+							$field: self.$field.as_std140(),
+						)*
+						..Zeroable::zeroed()
+					}
+				}
+			}
+
+			impl AsStd430 for $mint_ty {
+				type Std430Type = std430::$std_name;
+
+				fn as_std430(&self) -> Self::Std430Type {
+					std430::$std_name {
+						$(
+							$field: self.$field.as_std430(),
+						)*
+						..Zeroable::zeroed()
+					}
+				}
+			}
+		)*
+	};
 }
 
-impl AsStd140 for mint::ColumnMatrix2<f32> {
-    type Std140Type = std140::Mat2;
-
-    fn as_std140(&self) -> Self::Std140Type {
-        std140::Mat2 {
-            x: self.x.as_std140(),
-            y: self.y.as_std140(),
-            ..Zeroable::zeroed()
-        }
-    }
-}
-
-impl AsStd140 for mint::ColumnMatrix3<f32> {
-    type Std140Type = std140::Mat3;
-
-    fn as_std140(&self) -> Self::Std140Type {
-        std140::Mat3 {
-            x: self.x.as_std140(),
-            y: self.y.as_std140(),
-            z: self.z.as_std140(),
-            ..Zeroable::zeroed()
-        }
-    }
-}
-
-impl AsStd140 for mint::ColumnMatrix4<f32> {
-    type Std140Type = std140::Mat4;
-
-    fn as_std140(&self) -> Self::Std140Type {
-        std140::Mat4 {
-            x: self.x.as_std140(),
-            y: self.y.as_std140(),
-            z: self.z.as_std140(),
-            w: self.w.as_std140(),
-        }
-    }
+mint_matrices! {
+    mint::ColumnMatrix2<f32>, Mat2, (x, y),
+    mint::ColumnMatrix3<f32>, Mat3, (x, y, z),
+    mint::ColumnMatrix4<f32>, Mat4, (x, y, z, w),
 }

--- a/src/std430.rs
+++ b/src/std430.rs
@@ -1,0 +1,16 @@
+//! Defines traits and types for working with data adhering to GLSL's `std140`
+//! layout specification.
+
+// mod dynamic_uniform;
+// mod primitives;
+// mod sizer;
+mod traits;
+// mod writer;
+
+// pub use self::dynamic_uniform::*;
+// pub use self::primitives::*;
+// pub use self::sizer::*;
+pub use self::traits::*;
+// pub use self::writer::*;
+
+// pub use crevice_derive::AsStd140;

--- a/src/std430.rs
+++ b/src/std430.rs
@@ -1,16 +1,14 @@
 //! Defines traits and types for working with data adhering to GLSL's `std140`
 //! layout specification.
 
-// mod dynamic_uniform;
-// mod primitives;
-// mod sizer;
+mod primitives;
+mod sizer;
 mod traits;
-// mod writer;
+mod writer;
 
-// pub use self::dynamic_uniform::*;
-// pub use self::primitives::*;
-// pub use self::sizer::*;
+pub use self::primitives::*;
+pub use self::sizer::*;
 pub use self::traits::*;
-// pub use self::writer::*;
+pub use self::writer::*;
 
-// pub use crevice_derive::AsStd140;
+pub use crevice_derive::AsStd430;

--- a/src/std430/primitives.rs
+++ b/src/std430/primitives.rs
@@ -1,0 +1,131 @@
+use bytemuck::{Pod, Zeroable};
+
+use crate::std430::Std430;
+
+unsafe impl Std430 for f32 {
+    const ALIGNMENT: usize = 4;
+}
+
+unsafe impl Std430 for f64 {
+    const ALIGNMENT: usize = 8;
+}
+
+unsafe impl Std430 for i32 {
+    const ALIGNMENT: usize = 4;
+}
+
+unsafe impl Std430 for u32 {
+    const ALIGNMENT: usize = 4;
+}
+
+macro_rules! vectors {
+    (
+        $(
+            #[$doc:meta] align($align:literal) $name:ident <$prim:ident> ($($field:ident),+)
+        )+
+    ) => {
+        $(
+            #[$doc]
+            #[allow(missing_docs)]
+            #[derive(Debug, Clone, Copy)]
+            pub struct $name {
+                $(pub $field: $prim,)+
+            }
+
+            unsafe impl Zeroable for $name {}
+            unsafe impl Pod for $name {}
+
+            unsafe impl Std430 for $name {
+                const ALIGNMENT: usize = $align;
+            }
+        )+
+    };
+}
+
+vectors! {
+    #[doc = "Corresponds to a GLSL `vec2` in std430 layout."] align(8) Vec2<f32>(x, y)
+    #[doc = "Corresponds to a GLSL `vec3` in std430 layout."] align(16) Vec3<f32>(x, y, z)
+    #[doc = "Corresponds to a GLSL `vec4` in std430 layout."] align(16) Vec4<f32>(x, y, z, w)
+
+    #[doc = "Corresponds to a GLSL `dvec2` in std430 layout."] align(16) DVec2<f64>(x, y)
+    #[doc = "Corresponds to a GLSL `dvec3` in std430 layout."] align(32) DVec3<f64>(x, y, z)
+    #[doc = "Corresponds to a GLSL `dvec4` in std430 layout."] align(32) DVec4<f64>(x, y, z, w)
+}
+
+macro_rules! matrices {
+    (
+        $(
+            #[$doc:meta]
+            align($align:literal)
+            $name:ident {
+                $($field:ident: $field_ty:ty,)+
+            }
+        )+
+    ) => {
+        $(
+            #[$doc]
+            #[allow(missing_docs)]
+            #[derive(Debug, Clone, Copy)]
+            pub struct $name {
+                $(pub $field: $field_ty,)+
+            }
+
+            unsafe impl Zeroable for $name {}
+            unsafe impl Pod for $name {}
+
+            unsafe impl Std430 for $name {
+                const ALIGNMENT: usize = $align;
+            }
+        )+
+    };
+}
+
+matrices! {
+    #[doc = "Corresponds to a GLSL `mat2` in std430 layout."]
+    align(16)
+    Mat2 {
+        x: Vec2,
+        y: Vec2,
+    }
+
+    #[doc = "Corresponds to a GLSL `mat3` in std430 layout."]
+    align(16)
+    Mat3 {
+        x: Vec3,
+        y: Vec3,
+        z: Vec3,
+    }
+
+    #[doc = "Corresponds to a GLSL `mat4` in std430 layout."]
+    align(16)
+    Mat4 {
+        x: Vec4,
+        y: Vec4,
+        z: Vec4,
+        w: Vec4,
+    }
+
+    #[doc = "Corresponds to a GLSL `dmat2` in std430 layout."]
+    align(16)
+    DMat2 {
+        x: DVec2,
+        y: DVec2,
+    }
+
+    #[doc = "Corresponds to a GLSL `dmat3` in std430 layout."]
+    align(32)
+    DMat3 {
+        x: DVec3,
+        y: DVec3,
+        z: DVec3,
+    }
+
+    #[doc = "Corresponds to a GLSL `dmat3` in std430 layout."]
+    align(32)
+    DMat4 {
+        x: DVec4,
+        y: DVec4,
+        z: DVec4,
+        w: DVec4,
+    }
+}

--- a/src/std430/sizer.rs
+++ b/src/std430/sizer.rs
@@ -1,0 +1,81 @@
+use std::mem::size_of;
+
+use crate::internal::align_offset;
+use crate::std430::{AsStd430, Std430};
+
+/**
+Type that computes the buffer size needed by a series of `std430` types laid
+out.
+
+This type works well well when paired with `Writer`, precomputing a buffer's
+size to alleviate the need to dynamically re-allocate buffers.
+
+## Example
+
+```glsl
+struct Frob {
+    vec3 size;
+    float frobiness;
+}
+
+buffer FROBS {
+    uint len;
+    Frob[] frobs;
+} frobs;
+```
+
+```
+use crevice::std430::{self, AsStd430};
+
+#[derive(AsStd430)]
+struct Frob {
+    size: mint::Vector3<f32>,
+    frobiness: f32,
+}
+
+// Many APIs require that buffers contain at least enough space for all
+// fixed-size bindiongs to a buffer as well as one element of any arrays, if
+// there are any.
+let mut sizer = std430::Sizer::new();
+sizer.add::<u32>();
+sizer.add::<Frob>();
+
+# fn create_buffer_with_size(size: usize) {}
+let buffer = create_buffer_with_size(sizer.len());
+# assert_eq!(sizer.len(), 32);
+```
+*/
+pub struct Sizer {
+    offset: usize,
+}
+
+impl Sizer {
+    /// Create a new `Sizer`.
+    pub fn new() -> Self {
+        Self { offset: 0 }
+    }
+
+    /// Add a type's necessary padding and size to the `Sizer`. Returns the
+    /// offset into the buffer where that type would be written.
+    pub fn add<T>(&mut self) -> usize
+    where
+        T: AsStd430,
+    {
+        let size = size_of::<<T as AsStd430>::Std430Type>();
+        let alignment = <T as AsStd430>::Std430Type::ALIGNMENT;
+        let padding = align_offset(self.offset, alignment);
+
+        self.offset += padding;
+        let write_here = self.offset;
+
+        self.offset += size;
+
+        write_here
+    }
+
+    /// Returns the number of bytes required to contain all the types added to
+    /// the `Sizer`.
+    pub fn len(&self) -> usize {
+        self.offset
+    }
+}

--- a/src/std430/traits.rs
+++ b/src/std430/traits.rs
@@ -1,0 +1,91 @@
+use std::mem::size_of;
+
+use bytemuck::{bytes_of, Pod, Zeroable};
+
+/// Trait implemented for all `std430` primitives. Generally should not be
+/// implemented outside this crate.
+pub unsafe trait Std430: Copy + Zeroable + Pod {
+    /// The required alignment of the type. Must be a power of two.
+    ///
+    /// This is distinct from the value returned by `std::mem::align_of` because
+    /// `AsStd430` structs do not use Rust's alignment. This enables them to
+    /// control and zero their padding bytes, making converting them to and from
+    /// slices safe.
+    const ALIGNMENT: usize;
+
+    /// Casts the type to a byte array. Implementors should not override this
+    /// method.
+    ///
+    /// # Safety
+    /// This is always safe due to the requirements of [`bytemuck::Pod`] being a
+    /// prerequisite for this trait.
+    fn as_bytes(&self) -> &[u8] {
+        bytes_of(self)
+    }
+}
+
+/**
+Trait implemented for all types that can be turned into `std430` values.
+
+This trait can often be `#[derive]`'d instead of manually implementing it. Any
+struct which contains only fields that also implement `AsStd430` can derive
+`AsStd430`.
+
+Types from the mint crate implement `AsStd430`, making them convenient for use
+in uniform types. Most Rust geometry crates, like cgmath, nalgebra, and
+ultraviolet support mint.
+
+## Example
+
+```glsl
+uniform CAMERA {
+    mat4 view;
+    mat4 projection;
+} camera;
+```
+
+```skip
+use cgmath::prelude::*;
+use cgmath::{Matrix4, Deg, perspective};
+use crevice::std430::{AsStd430, Std430};
+
+#[derive(AsStd430)]
+struct CameraUniform {
+    view: mint::ColumnMatrix4<f32>,
+    projection: mint::ColumnMatrix4<f32>,
+}
+
+let camera = CameraUniform {
+    view: Matrix4::identity().into(),
+    projection: perspective(Deg(60.0), 16.0/9.0, 0.01, 100.0).into(),
+};
+
+# fn write_to_gpu_buffer(bytes: &[u8]) {}
+let camera_std430 = camera.as_std430();
+write_to_gpu_buffer(camera_std430.as_bytes());
+```
+*/
+pub trait AsStd430 {
+    /// The `std430` version of this value.
+    type Std430Type: Std430;
+
+    /// Convert this value into the `std430` version of itself.
+    fn as_std430(&self) -> Self::Std430Type;
+
+    /// Returns the size of the `std430` version of this type. Useful for
+    /// pre-sizing buffers.
+    fn std430_size(&self) -> usize {
+        size_of::<Self::Std430Type>()
+    }
+}
+
+impl<T> AsStd430 for T
+where
+    T: Std430,
+{
+    type Std430Type = Self;
+
+    fn as_std430(&self) -> Self {
+        *self
+    }
+}

--- a/src/std430/writer.rs
+++ b/src/std430/writer.rs
@@ -1,0 +1,148 @@
+use std::io::{self, Write};
+use std::mem::size_of;
+
+use bytemuck::bytes_of;
+
+use crate::internal::align_offset;
+use crate::std430::{AsStd430, Std430, WriteStd430};
+
+/**
+Type that enables writing correctly aligned `std430` values to a buffer.
+
+`Writer` is useful when many values need to be laid out in a row that cannot be
+represented by a struct alone, like dynamically sized arrays or dynamically
+laid-out values.
+
+## Example
+In this example, we'll write a length-prefixed list of lights to a buffer.
+`std430::Writer` helps align correctly, even across multiple structs, which can
+be tricky and error-prone otherwise.
+
+```glsl
+struct PointLight {
+    vec3 position;
+    vec3 color;
+    float brightness;
+};
+
+buffer POINT_LIGHTS {
+    uint len;
+    PointLight[] lights;
+} point_lights;
+```
+
+```
+use crevice::std430::{self, AsStd430};
+
+#[derive(AsStd430)]
+struct PointLight {
+    position: mint::Vector3<f32>,
+    color: mint::Vector3<f32>,
+    brightness: f32,
+}
+
+let lights = vec![
+    PointLight {
+        position: [0.0, 1.0, 0.0].into(),
+        color: [1.0, 0.0, 0.0].into(),
+        brightness: 0.6,
+    },
+    PointLight {
+        position: [0.0, 4.0, 3.0].into(),
+        color: [1.0, 1.0, 1.0].into(),
+        brightness: 1.0,
+    },
+];
+
+# fn map_gpu_buffer_for_write() -> &'static mut [u8] {
+#     Box::leak(vec![0; 1024].into_boxed_slice())
+# }
+let target_buffer = map_gpu_buffer_for_write();
+let mut writer = std430::Writer::new(target_buffer);
+
+let light_count = lights.len() as u32;
+writer.write(&light_count)?;
+
+// Crevice will automatically insert the required padding to align the
+// PointLight structure correctly. In this case, there will be 12 bytes of
+// padding between the length field and the light list.
+
+writer.write(lights.as_slice())?;
+
+# fn unmap_gpu_buffer() {}
+unmap_gpu_buffer();
+
+# Ok::<(), std::io::Error>(())
+```
+*/
+pub struct Writer<W> {
+    writer: W,
+    offset: usize,
+}
+
+impl<W: Write> Writer<W> {
+    /// Create a new `Writer`, wrapping a buffer, file, or other type that
+    /// implements [`std::io::Write`].
+    pub fn new(writer: W) -> Self {
+        Self { writer, offset: 0 }
+    }
+
+    /// Write a new value to the underlying buffer, writing zeroed padding where
+    /// necessary.
+    ///
+    /// Returns the offset into the buffer that the value was written to.
+    pub fn write<T>(&mut self, value: &T) -> io::Result<usize>
+    where
+        T: WriteStd430 + ?Sized,
+    {
+        value.write_std430(self)
+    }
+
+    /// Write an iterator of values to the underlying buffer.
+    ///
+    /// Returns the offset into the buffer that the first value was written to.
+    /// If no values were written, returns the `len()`.
+    pub fn write_iter<I, T>(&mut self, iter: I) -> io::Result<usize>
+    where
+        I: IntoIterator<Item = T>,
+        T: WriteStd430,
+    {
+        let mut first_offset = None;
+
+        for item in iter {
+            let offset = item.write_std430(self)?;
+
+            if first_offset.is_none() {
+                first_offset = Some(offset);
+            }
+        }
+
+        Ok(first_offset.unwrap_or(self.offset))
+    }
+
+    /// Write an `Std430` type to the underlying buffer.
+    pub fn write_std430<T>(&mut self, value: &T) -> io::Result<usize>
+    where
+        T: Std430,
+    {
+        let padding = align_offset(self.offset, T::ALIGNMENT);
+
+        for _ in 0..padding {
+            self.writer.write_all(&[0])?;
+        }
+        self.offset += padding;
+
+        let value = value.as_std430();
+        self.writer.write_all(bytes_of(&value))?;
+
+        let write_here = self.offset;
+        self.offset += size_of::<T>();
+
+        Ok(write_here)
+    }
+
+    /// Returns the amount of data written by this `Writer`.
+    pub fn len(&self) -> usize {
+        self.offset
+    }
+}


### PR DESCRIPTION
Closes #1.

This PR introduces an `std430` module to go alongside `std140`. It supports pretty much all of the same things!

With the exception of a couple important refactors (derive macro, mint impls), this PR is mostly just mechanical copy-and-paste. I wish we had a way to make a type parameterized by a trait, heh.