### PR TITLE
Add WriteStd140 trait and ripple out its implications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Crevice Changelog
 
 ## Unreleased Changes
+* Deprecated `Sizer` in favor of using `std140::Writer` paired with [`std::io::sink`](https://doc.rust-lang.org/stable/std/io/fn.sink.html). These should be equivalent.
+* Deprecated `Writer::write_slice`, as `Writer::write` now accepts slices.
+* Added the `WriteStd140` trait. This trait is more general than `AsStd140` and is automatically implemented for all existing `AsStd140` implementers.
+* Added `Writer::write_std140` to write a type that implements `Std140`.
+* Changed bounds of some functions, like `Writer::write` to use `WriteStd140` instead of `AsStd140`. This should affect no existing consumers.
 
 ## 0.5.0 (2020-10-18)
 * Added f64-based std140 types: `DVec2`, `DVec3`, `DVec4`, `DMat2`, `DMat3`, and `DMat4`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,8 @@
 [![crevice docs](https://img.shields.io/badge/docs-docs.rs-orange.svg)](https://docs.rs/crevice)
 
 Crevice creates GLSL-compatible versions of types through the power of derive
-macros. Generated structures provide an [`as_bytes`][Std140::as_bytes] method to allow safely packing data into buffers for uploading.
+macros. Generated structures provide an [`as_bytes`][Std140::as_bytes] method to
+allow safely packing data into buffers for uploading.
 
 Generated structs also implement [`bytemuck::Zeroable`] and
 [`bytemuck::Pod`] for use with other libraries.
@@ -109,11 +110,7 @@ writer.write(&light_count)?;
 // PointLight structure correctly. In this case, there will be 12 bytes of
 // padding between the length field and the light list.
 
-for light in &lights {
-    writer.write(light)?;
-
-    // Crevice will also pad between each array element.
-}
+writer.write(lights.as_slice())?;
 
 # fn unmap_gpu_buffer() {}
 unmap_gpu_buffer();

--- a/src/std140/sizer.rs
+++ b/src/std140/sizer.rs
@@ -1,3 +1,7 @@
+// This module defines a deprecated type, but we don't want to warn on our own
+// usage of it in the module defining it.
+#![allow(deprecated)]
+
 use std::mem::size_of;
 
 use crate::internal::align_offset;
@@ -45,6 +49,7 @@ let buffer = create_buffer_with_size(sizer.len());
 # assert_eq!(sizer.len(), 32);
 ```
 */
+#[deprecated(since = "0.6.0", note = "Use Writer with std::io::sink() instead")]
 pub struct Sizer {
     offset: usize,
 }

--- a/src/std140/traits.rs
+++ b/src/std140/traits.rs
@@ -1,6 +1,9 @@
+use std::io::{self, Write};
 use std::mem::size_of;
 
 use bytemuck::{bytes_of, Pod, Zeroable};
+
+use crate::std140::Writer;
 
 /// Trait implemented for all `std140` primitives. Generally should not be
 /// implemented outside this crate.
@@ -87,5 +90,64 @@ where
 
     fn as_std140(&self) -> Self {
         *self
+    }
+}
+
+/// Trait implemented for all types that can be written into a buffer as
+/// `std140` bytes. This type is more general than [`AsStd140`]: all `AsStd140`
+/// types implement `WriteStd140`, but not the other way around.
+///
+/// While `AsStd140` requires implementers to return a type that implements the
+/// `Std140` trait, `WriteStd140` directly writes bytes using a [`Writer`]. This
+/// makes `WriteStd140` usable for writing slices or other DSTs that could not
+/// implement `AsStd140` without allocating new memory on the heap.
+pub trait WriteStd140 {
+    /// Writes this value into the given [`Writer`] using `std140` layout rules.
+    ///
+    /// Should return the offset of the first byte of this type, as returned by
+    /// the first call to [`Writer::write`].
+    fn write_std140<W: Write>(&self, writer: &mut Writer<W>) -> io::Result<usize>;
+
+    /// The space required to write this value using `std140` layout rules. This
+    /// does not include alignment padding that may be needed before or after
+    /// this type when written as part of a larger buffer.
+    fn size(&self) -> usize;
+}
+
+impl<T> WriteStd140 for T
+where
+    T: AsStd140,
+{
+    fn write_std140<W: Write>(&self, writer: &mut Writer<W>) -> io::Result<usize> {
+        writer.write_std140(&self.as_std140())
+    }
+
+    fn size(&self) -> usize {
+        self.std140_size()
+    }
+}
+
+impl<T> WriteStd140 for [T]
+where
+    T: WriteStd140,
+{
+    fn write_std140<W: Write>(&self, writer: &mut Writer<W>) -> io::Result<usize> {
+        let mut offset = None;
+
+        for item in self.iter() {
+            let item_offset = item.write_std140(writer)?;
+
+            if offset.is_none() {
+                offset = Some(item_offset);
+            }
+        }
+
+        Ok(offset.unwrap_or(writer.len()))
+    }
+
+    fn size(&self) -> usize {
+        let mut writer = Writer::new(io::sink());
+        self.write_std140(&mut writer).unwrap();
+        writer.len()
     }
 }


### PR DESCRIPTION
Closes #14.

This PR adds a new trait, `WriteStd140`, to act as a more general version of `AsStd140`. This resulted in a handful of other things being adjusted. See `CHANGELOG.md` for the full list.

This enables writing slices and other types that dynamic layout into buffers. It wasn't possible to do this using `AsStd140` without making those types allocate memory on the heap, but now we have a more general trait. Methods on this new trait take `&self`, since they're dependent on the contained value, not just its type.