### PR TITLE
Added proper padding after structs (and matrices).

### DIFF
--- a/crevice-derive/src/lib.rs
+++ b/crevice-derive/src/lib.rs
@@ -130,12 +130,10 @@ impl EmitOptions {
                             }
                         });
 
-                let pad_at_end = fields
-                    .named
-                    .iter()
-                    .take(index)
-                    .next_back()
-                    .map_or(quote!{0usize}, |field|{
+                let pad_at_end = index
+                    .checked_sub(1)
+                    .map_or(quote!{0usize}, |prev_index|{
+                        let field = &fields.named[prev_index];
                         let field_ty = &field.ty;
                         quote! {
                             if <<#field_ty as #as_trait_path>::#as_trait_assoc as #mod_path::#layout_name>::PAD_AT_END {

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -21,3 +21,12 @@ pub const fn max(a: usize, b: usize) -> usize {
         b
     }
 }
+
+pub const fn pad_at_end(size: usize, alignment: usize, do_pad: bool) -> usize {
+    if do_pad {
+        align_offset(size, alignment)
+    }
+    else {
+        0
+    }
+}

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -21,12 +21,3 @@ pub const fn max(a: usize, b: usize) -> usize {
         b
     }
 }
-
-pub const fn pad_at_end(size: usize, alignment: usize, do_pad: bool) -> usize {
-    if do_pad {
-        align_offset(size, alignment)
-    }
-    else {
-        0
-    }
-}

--- a/src/std140/primitives.rs
+++ b/src/std140/primitives.rs
@@ -87,6 +87,8 @@ macro_rules! matrices {
 
             unsafe impl Std140 for $name {
                 const ALIGNMENT: usize = $align;
+                /// Matrices are technically arrays of primitives, and as such require pad at end.
+                const PAD_AT_END: bool = true;
             }
         )+
     };

--- a/src/std140/traits.rs
+++ b/src/std140/traits.rs
@@ -15,6 +15,11 @@ pub unsafe trait Std140: Copy + Zeroable + Pod {
     /// control and zero their padding bytes, making converting them to and from
     /// slices safe.
     const ALIGNMENT: usize;
+    /// Whether this type requires a padding at the end (ie, is a struct or an array
+    /// of primitives).
+    /// See https://www.khronos.org/registry/OpenGL/specs/gl/glspec45.core.pdf#page=159
+    /// (rule 4 and 9)
+    const PAD_AT_END: bool = false;
 
     /// Casts the type to a byte array. Implementors should not override this
     /// method.

--- a/src/std430/primitives.rs
+++ b/src/std430/primitives.rs
@@ -87,6 +87,8 @@ macro_rules! matrices {
 
             unsafe impl Std430 for $name {
                 const ALIGNMENT: usize = $align;
+                /// Matrices are technically arrays of primitives, and as such require pad at end.
+                const PAD_AT_END: bool = true;
             }
         )+
     };

--- a/src/std430/traits.rs
+++ b/src/std430/traits.rs
@@ -15,6 +15,11 @@ pub unsafe trait Std430: Copy + Zeroable + Pod {
     /// control and zero their padding bytes, making converting them to and from
     /// slices safe.
     const ALIGNMENT: usize;
+    /// Whether this type requires a padding at the end (ie, is a struct or an array
+    /// of primitives).
+    /// See https://www.khronos.org/registry/OpenGL/specs/gl/glspec45.core.pdf#page=159
+    /// (rule 4 and 9)
+    const PAD_AT_END: bool = false;
 
     /// Casts the type to a byte array. Implementors should not override this
     /// method.

--- a/tests/snapshots/std140__matrix_uniform_std140.snap
+++ b/tests/snapshots/std140__matrix_uniform_std140.snap
@@ -1,0 +1,26 @@
+---
+source: tests/std140.rs
+expression: "<<MatrixUniform as AsStd140>::Std140Type as TypeLayout>::type_layout()"
+
+---
+name: Std140MatrixUniform
+size: 52
+alignment: 4
+fields:
+  - Field:
+      name: _e_align
+      ty: "[u8 ; Std140MatrixUniformAlignment :: _e_align()]"
+      size: 0
+  - Field:
+      name: e
+      ty: "< mint :: ColumnMatrix3 < f32 > as :: crevice :: std140 :: AsStd140 > ::\nStd140Type"
+      size: 48
+  - Field:
+      name: _f_align
+      ty: "[u8 ; Std140MatrixUniformAlignment :: _f_align()]"
+      size: 0
+  - Field:
+      name: f
+      ty: "< f32 as :: crevice :: std140 :: AsStd140 > :: Std140Type"
+      size: 4
+

--- a/tests/snapshots/std140__matrix_uniform_std430.snap
+++ b/tests/snapshots/std140__matrix_uniform_std430.snap
@@ -1,0 +1,26 @@
+---
+source: tests/std140.rs
+expression: "<<MatrixUniform as AsStd430>::Std430Type as TypeLayout>::type_layout()"
+
+---
+name: Std430MatrixUniform
+size: 52
+alignment: 4
+fields:
+  - Field:
+      name: _e_align
+      ty: "[u8 ; Std430MatrixUniformAlignment :: _e_align()]"
+      size: 0
+  - Field:
+      name: e
+      ty: "< mint :: ColumnMatrix3 < f32 > as :: crevice :: std430 :: AsStd430 > ::\nStd430Type"
+      size: 36
+  - Field:
+      name: _f_align
+      ty: "[u8 ; Std430MatrixUniformAlignment :: _f_align()]"
+      size: 12
+  - Field:
+      name: f
+      ty: "< f32 as :: crevice :: std430 :: AsStd430 > :: Std430Type"
+      size: 4
+

--- a/tests/snapshots/std140__padding_at_end.snap
+++ b/tests/snapshots/std140__padding_at_end.snap
@@ -1,0 +1,26 @@
+---
+source: tests/std140.rs
+expression: "<<PaddingAtEnd as AsStd140>::Std140Type as TypeLayout>::type_layout()"
+
+---
+name: Std140PaddingAtEnd
+size: 20
+alignment: 4
+fields:
+  - Field:
+      name: _base_value_align
+      ty: "[u8 ; Std140PaddingAtEndAlignment :: _base_value_align()]"
+      size: 0
+  - Field:
+      name: base_value
+      ty: "< PrimitiveF32 as :: crevice :: std140 :: AsStd140 > :: Std140Type"
+      size: 8
+  - Field:
+      name: _small_field_align
+      ty: "[u8 ; Std140PaddingAtEndAlignment :: _small_field_align()]"
+      size: 8
+  - Field:
+      name: small_field
+      ty: "< f32 as :: crevice :: std140 :: AsStd140 > :: Std140Type"
+      size: 4
+

--- a/tests/snapshots/std140__proper_offset_calculations_for_differing_member_sizes.snap
+++ b/tests/snapshots/std140__proper_offset_calculations_for_differing_member_sizes.snap
@@ -1,0 +1,26 @@
+---
+source: tests/std140.rs
+expression: "<<ProperlyChecksForUnderlyingTypeSize as AsStd140>::Std140Type as\n    TypeLayout>::type_layout()"
+
+---
+name: Std140ProperlyChecksForUnderlyingTypeSize
+size: 36
+alignment: 4
+fields:
+  - Field:
+      name: _leading_align
+      ty: "[u8 ; Std140ProperlyChecksForUnderlyingTypeSizeAlignment :: _leading_align()]"
+      size: 0
+  - Field:
+      name: leading
+      ty: "< BaseSizeAndStdSizeAreDifferent as :: crevice :: std140 :: AsStd140 > ::\nStd140Type"
+      size: 20
+  - Field:
+      name: _trailing_align
+      ty: "[u8 ; Std140ProperlyChecksForUnderlyingTypeSizeAlignment :: _trailing_align()]"
+      size: 12
+  - Field:
+      name: trailing
+      ty: "< PaddedByStdButNotRust as :: crevice :: std140 :: AsStd140 > :: Std140Type"
+      size: 4
+

--- a/tests/std140.rs
+++ b/tests/std140.rs
@@ -1,7 +1,8 @@
 use insta::assert_yaml_snapshot;
-use type_layout::TypeLayout;
+use type_layout::{TypeLayout, TypeLayoutInfo};
 
 use crevice::std140::{AsStd140, DVec4, Std140, Vec3};
+use crevice::std430::{AsStd430};
 
 #[derive(AsStd140)]
 struct PrimitiveF32 {
@@ -72,6 +73,33 @@ fn using_vec3_padding() {
 }
 
 #[derive(AsStd140)]
+struct UsingVec3PaddingWithMint {
+    pos: mint::Vector3<f32>,
+    brightness: f32
+}
+
+#[test]
+fn mint_type_produces_same_padding() {
+    let layout_vec: TypeLayoutInfo = <<UsingVec3Padding as AsStd140>::Std140Type as TypeLayout>::type_layout();
+    let layout_mint: TypeLayoutInfo = <<UsingVec3PaddingWithMint as AsStd140>::Std140Type as TypeLayout>::type_layout();
+    assert_eq!(layout_vec.size, layout_mint.size);
+    assert_eq!(layout_vec.alignment, layout_mint.alignment);
+    layout_vec.fields.iter().zip(layout_mint.fields.iter()).for_each(
+        |(field_vec, field_mint)| {
+            use type_layout::Field::*;
+            match (field_vec, field_mint) {
+                (Field{size : S1, ..}, Field {size: S2, ..}) =>
+                    assert_eq!(S1, S2),
+                (Padding {size: S1}, Padding{size:S2}) =>
+                    assert_eq!(S1, S2),
+                _ =>
+                    panic!("Different fields: {:?} and {:?}", field_vec, field_mint)
+            }
+        }
+    )
+}
+
+#[derive(AsStd140)]
 struct PointLight {
     position: Vec3,
     diffuse: Vec3,
@@ -118,4 +146,37 @@ fn more_than_16_alignment() {
     );
 
     assert_eq!(<MoreThan16Alignment as AsStd140>::Std140Type::ALIGNMENT, 32);
+}
+
+#[derive(AsStd140)]
+struct PaddingAtEnd {
+    base_value: PrimitiveF32,
+    small_field: f32
+}
+
+#[test]
+fn padding_at_end() {
+    assert_yaml_snapshot!(
+        <<PaddingAtEnd as AsStd140>::Std140Type as TypeLayout>::type_layout()
+    );
+}
+
+#[derive(AsStd140, AsStd430)]
+struct MatrixUniform {
+    e: mint::ColumnMatrix3<f32>,
+    f: f32,
+}
+
+#[test]
+fn matrix_uniform_std140() {
+    assert_yaml_snapshot!(
+        <<MatrixUniform as AsStd140>::Std140Type as TypeLayout>::type_layout()
+    )
+}
+
+#[test]
+fn matrix_uniform_std430() {
+    assert_yaml_snapshot!(
+        <<MatrixUniform as AsStd430>::Std430Type as TypeLayout>::type_layout()
+    )
 }

--- a/tests/std140.rs
+++ b/tests/std140.rs
@@ -2,7 +2,7 @@ use insta::assert_yaml_snapshot;
 use type_layout::TypeLayout;
 
 use crevice::std140::{AsStd140, DVec4, Std140, Vec3};
-use crevice::std430::{AsStd430};
+use crevice::std430::AsStd430;
 
 #[derive(AsStd140)]
 struct PrimitiveF32 {
@@ -124,14 +124,12 @@ fn more_than_16_alignment() {
 #[derive(AsStd140)]
 struct PaddingAtEnd {
     base_value: PrimitiveF32,
-    small_field: f32
+    small_field: f32,
 }
 
 #[test]
 fn padding_at_end() {
-    assert_yaml_snapshot!(
-        <<PaddingAtEnd as AsStd140>::Std140Type as TypeLayout>::type_layout()
-    );
+    assert_yaml_snapshot!(<<PaddingAtEnd as AsStd140>::Std140Type as TypeLayout>::type_layout());
 }
 
 #[derive(AsStd140, AsStd430)]
@@ -142,23 +140,19 @@ struct MatrixUniform {
 
 #[test]
 fn matrix_uniform_std140() {
-    assert_yaml_snapshot!(
-        <<MatrixUniform as AsStd140>::Std140Type as TypeLayout>::type_layout()
-    )
+    assert_yaml_snapshot!(<<MatrixUniform as AsStd140>::Std140Type as TypeLayout>::type_layout())
 }
 
 #[test]
 fn matrix_uniform_std430() {
-    assert_yaml_snapshot!(
-        <<MatrixUniform as AsStd430>::Std430Type as TypeLayout>::type_layout()
-    )
+    assert_yaml_snapshot!(<<MatrixUniform as AsStd430>::Std430Type as TypeLayout>::type_layout())
 }
 
 /// Rust size: 4, align: 4
 /// Std140 size: 4, align: 16
 #[derive(AsStd140)]
 struct PaddedByStdButNotRust {
-    x: f32
+    x: f32,
 }
 
 /// Rust size: 8, align: 4
@@ -166,7 +160,7 @@ struct PaddedByStdButNotRust {
 #[derive(AsStd140)]
 struct BaseSizeAndStdSizeAreDifferent {
     first: PaddedByStdButNotRust,
-    second: PaddedByStdButNotRust
+    second: PaddedByStdButNotRust,
 }
 
 /// If checking for base struct size, produces layout:
@@ -175,12 +169,13 @@ struct BaseSizeAndStdSizeAreDifferent {
 #[derive(AsStd140)]
 struct ProperlyChecksForUnderlyingTypeSize {
     leading: BaseSizeAndStdSizeAreDifferent,
-    trailing: PaddedByStdButNotRust
+    trailing: PaddedByStdButNotRust,
 }
 
 #[test]
 fn proper_offset_calculations_for_differing_member_sizes() {
     assert_yaml_snapshot!(
-        <<ProperlyChecksForUnderlyingTypeSize as AsStd140>::Std140Type as TypeLayout>::type_layout()
+        <<ProperlyChecksForUnderlyingTypeSize as AsStd140>::Std140Type as TypeLayout>::type_layout(
+        )
     )
 }

--- a/tests/std140.rs
+++ b/tests/std140.rs
@@ -73,33 +73,6 @@ fn using_vec3_padding() {
 }
 
 #[derive(AsStd140)]
-struct UsingVec3PaddingWithMint {
-    pos: mint::Vector3<f32>,
-    brightness: f32
-}
-
-#[test]
-fn mint_type_produces_same_padding() {
-    let layout_vec: TypeLayoutInfo = <<UsingVec3Padding as AsStd140>::Std140Type as TypeLayout>::type_layout();
-    let layout_mint: TypeLayoutInfo = <<UsingVec3PaddingWithMint as AsStd140>::Std140Type as TypeLayout>::type_layout();
-    assert_eq!(layout_vec.size, layout_mint.size);
-    assert_eq!(layout_vec.alignment, layout_mint.alignment);
-    layout_vec.fields.iter().zip(layout_mint.fields.iter()).for_each(
-        |(field_vec, field_mint)| {
-            use type_layout::Field::*;
-            match (field_vec, field_mint) {
-                (Field{size : S1, ..}, Field {size: S2, ..}) =>
-                    assert_eq!(S1, S2),
-                (Padding {size: S1}, Padding{size:S2}) =>
-                    assert_eq!(S1, S2),
-                _ =>
-                    panic!("Different fields: {:?} and {:?}", field_vec, field_mint)
-            }
-        }
-    )
-}
-
-#[derive(AsStd140)]
 struct PointLight {
     position: Vec3,
     diffuse: Vec3,


### PR DESCRIPTION
According to GLSL standard, within a struct, sturct and primitive
array members have "padding at end", ie next member essentially has
an alignment no less than the struct or the array itself.

Fixes #16.
Fixes #17.