### PR TITLE
Implement crevice for more mint types

### DIFF
--- a/src/mint.rs
+++ b/src/mint.rs
@@ -37,6 +37,22 @@ mint_vectors! {
     mint::Vector2<f32>, Vec2, (x, y),
     mint::Vector3<f32>, Vec3, (x, y, z),
     mint::Vector4<f32>, Vec4, (x, y, z, w),
+
+    mint::Vector2<i32>, IVec2, (x, y),
+    mint::Vector3<i32>, IVec3, (x, y, z),
+    mint::Vector4<i32>, IVec4, (x, y, z, w),
+
+    mint::Vector2<u32>, UVec2, (x, y),
+    mint::Vector3<u32>, UVec3, (x, y, z),
+    mint::Vector4<u32>, UVec4, (x, y, z, w),
+
+    mint::Vector2<bool>, BVec2, (x, y),
+    mint::Vector3<bool>, BVec3, (x, y, z),
+    mint::Vector4<bool>, BVec4, (x, y, z, w),
+
+    mint::Vector2<f64>, DVec2, (x, y),
+    mint::Vector3<f64>, DVec3, (x, y, z),
+    mint::Vector4<f64>, DVec4, (x, y, z, w),
 }
 
 macro_rules! mint_matrices {
@@ -75,4 +91,8 @@ mint_matrices! {
     mint::ColumnMatrix2<f32>, Mat2, (x, y),
     mint::ColumnMatrix3<f32>, Mat3, (x, y, z),
     mint::ColumnMatrix4<f32>, Mat4, (x, y, z, w),
+
+    mint::ColumnMatrix2<f64>, DMat2, (x, y),
+    mint::ColumnMatrix3<f64>, DMat3, (x, y, z),
+    mint::ColumnMatrix4<f64>, DMat4, (x, y, z, w),
 }


### PR DESCRIPTION
Allow i32, u32, bool and f64 to be used as components in mint vector types.