### PR TITLE
Conversion from Std* types back into AsStd* types.

### DIFF
--- a/crevice-derive/src/lib.rs
+++ b/crevice-derive/src/lib.rs
@@ -45,7 +45,7 @@ struct EmitOptions {
     as_trait_method: Ident,
 
     // The name of the method used to convert from Trait to AsTrait.
-    from_trait_method: Ident
+    from_trait_method: Ident,
 }
 
 impl EmitOptions {

--- a/src/mint.rs
+++ b/src/mint.rs
@@ -16,6 +16,14 @@ macro_rules! mint_vectors {
                         )*
                     }
                 }
+
+                fn from_std140(value: Self::Std140Type) -> Self {
+                    Self {
+                        $(
+                            $field: value.$field,
+                        )*
+                    }
+                }
             }
 
             impl AsStd430 for $mint_ty {
@@ -25,6 +33,14 @@ macro_rules! mint_vectors {
                     std430::$std_name {
                         $(
                             $field: self.$field,
+                        )*
+                    }
+                }
+
+                fn from_std430(value: Self::Std430Type) -> Self {
+                    Self {
+                        $(
+                            $field: value.$field,
                         )*
                     }
                 }
@@ -53,6 +69,14 @@ macro_rules! mint_matrices {
                         ..Zeroable::zeroed()
                     }
                 }
+
+                fn from_std140(value: Self::Std140Type) -> Self {
+                    Self {
+                        $(
+                            $field: <_ as AsStd140>::from_std140(value.$field),
+                        )*
+                    }
+                }
             }
 
             impl AsStd430 for $mint_ty {
@@ -64,6 +88,14 @@ macro_rules! mint_matrices {
                             $field: self.$field.as_std430(),
                         )*
                         ..Zeroable::zeroed()
+                    }
+                }
+
+                fn from_std430(value: Self::Std430Type) -> Self {
+                    Self {
+                        $(
+                            $field: <_ as AsStd430>::from_std430(value.$field),
+                        )*
                     }
                 }
             }

--- a/src/std140/dynamic_uniform.rs
+++ b/src/std140/dynamic_uniform.rs
@@ -15,6 +15,10 @@ impl<T: AsStd140> AsStd140 for DynamicUniform<T> {
     fn as_std140(&self) -> Self::Std140Type {
         DynamicUniformStd140(self.0.as_std140())
     }
+
+    fn from_std140(value: Self::Std140Type) -> Self {
+        DynamicUniform(<T as AsStd140>::from_std140(value.0))
+    }
 }
 
 /// std140 variant of [`DynamicUniform`].

--- a/src/std140/traits.rs
+++ b/src/std140/traits.rs
@@ -95,7 +95,9 @@ where
         *self
     }
 
-    fn from_std140(x: Self) -> Self {x}
+    fn from_std140(x: Self) -> Self {
+        x
+    }
 }
 
 /// Trait implemented for all types that can be written into a buffer as

--- a/src/std140/traits.rs
+++ b/src/std140/traits.rs
@@ -80,6 +80,9 @@ pub trait AsStd140 {
     fn std140_size_static() -> usize {
         size_of::<Self::Std140Type>()
     }
+
+    /// Converts from `std140` version of self to self.
+    fn from_std140(val: Self::Std140Type) -> Self;
 }
 
 impl<T> AsStd140 for T
@@ -91,6 +94,8 @@ where
     fn as_std140(&self) -> Self {
         *self
     }
+
+    fn from_std140(x: Self) -> Self {x}
 }
 
 /// Trait implemented for all types that can be written into a buffer as

--- a/src/std430/traits.rs
+++ b/src/std430/traits.rs
@@ -80,6 +80,9 @@ pub trait AsStd430 {
     fn std430_size_static() -> usize {
         size_of::<Self::Std430Type>()
     }
+
+    /// Converts from `std430` version of self to self.
+    fn from_std430(value: Self::Std430Type) -> Self;
 }
 
 impl<T> AsStd430 for T
@@ -91,6 +94,8 @@ where
     fn as_std430(&self) -> Self {
         *self
     }
+
+    fn from_std430(value: Self) -> Self {value}
 }
 
 /// Trait implemented for all types that can be written into a buffer as

--- a/src/std430/traits.rs
+++ b/src/std430/traits.rs
@@ -95,7 +95,9 @@ where
         *self
     }
 
-    fn from_std430(value: Self) -> Self {value}
+    fn from_std430(value: Self) -> Self {
+        value
+    }
 }
 
 /// Trait implemented for all types that can be written into a buffer as

--- a/tests/std140.rs
+++ b/tests/std140.rs
@@ -123,18 +123,34 @@ fn more_than_16_alignment() {
 #[derive(AsStd140, Debug, PartialEq)]
 struct ThereAndBackAgain {
     view: mint::ColumnMatrix3<f32>,
-    origin: mint::Vector3<f32>
+    origin: mint::Vector3<f32>,
 }
 
 #[test]
 fn there_and_back_again() {
-    let x = ThereAndBackAgain{
-        view: mint::ColumnMatrix3{
-            x: mint::Vector3{x:1.0, y:0.0, z:0.0},
-            y: mint::Vector3{x:0.0, y:1.0, z:0.0},
-            z: mint::Vector3{x:0.0, y:0.0, z:1.0},
+    let x = ThereAndBackAgain {
+        view: mint::ColumnMatrix3 {
+            x: mint::Vector3 {
+                x: 1.0,
+                y: 0.0,
+                z: 0.0,
+            },
+            y: mint::Vector3 {
+                x: 0.0,
+                y: 1.0,
+                z: 0.0,
+            },
+            z: mint::Vector3 {
+                x: 0.0,
+                y: 0.0,
+                z: 1.0,
+            },
         },
-        origin: mint::Vector3{x:0.0, y: 1.0, z: 2.0}
+        origin: mint::Vector3 {
+            x: 0.0,
+            y: 1.0,
+            z: 2.0,
+        },
     };
     let x_as = x.as_std140();
     assert_eq!(<ThereAndBackAgain as AsStd140>::from_std140(x_as), x);

--- a/tests/std140.rs
+++ b/tests/std140.rs
@@ -119,3 +119,23 @@ fn more_than_16_alignment() {
 
     assert_eq!(<MoreThan16Alignment as AsStd140>::Std140Type::ALIGNMENT, 32);
 }
+
+#[derive(AsStd140, Debug, PartialEq)]
+struct ThereAndBackAgain {
+    view: mint::ColumnMatrix3<f32>,
+    origin: mint::Vector3<f32>
+}
+
+#[test]
+fn there_and_back_again() {
+    let x = ThereAndBackAgain{
+        view: mint::ColumnMatrix3{
+            x: mint::Vector3{x:1.0, y:0.0, z:0.0},
+            y: mint::Vector3{x:0.0, y:1.0, z:0.0},
+            z: mint::Vector3{x:0.0, y:0.0, z:1.0},
+        },
+        origin: mint::Vector3{x:0.0, y: 1.0, z: 2.0}
+    };
+    let x_as = x.as_std140();
+    assert_eq!(<ThereAndBackAgain as AsStd140>::from_std140(x_as), x);
+}


### PR DESCRIPTION
Closes #6.

Implemented in a kind of a dumb way - you have to write `<_ as AsStd140>::from_std140(v)`.

Compiler is at least able to infer types since from_ functions are constrained to return Self.