### PR TITLE
Support all math libraries using `IntoMint`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ resolver = "2"
 
 [patch.crates-io]
 mint = { git = "https://github.com/LPGhatguy/mint", branch = "into-mint" }
+glam = { git = "https://github.com/LPGhatguy/glam-rs", branch = "into-mint" }
 
 [features]
 default = ["std"]

--- a/crevice-tests/Cargo.toml
+++ b/crevice-tests/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = "1.0.44"
 bytemuck = "1.7.2"
 memoffset = "0.6.4"
 mint = "0.5.5"
+glam = { version = "0.19.0", features = ["mint"] }
 
 futures = { version = "0.3.17", features = ["executor"], optional = true }
 naga = { version = "0.7.0", features = ["glsl-in", "wgsl-out"], optional = true }

--- a/crevice-tests/src/lib.rs
+++ b/crevice-tests/src/lib.rs
@@ -21,6 +21,24 @@ use crevice::std430::AsStd430;
 use mint::{ColumnMatrix2, ColumnMatrix3, ColumnMatrix4, Vector2, Vector3, Vector4};
 
 #[test]
+fn why_not_glam() {
+    #[derive(AsStd140)]
+    struct UsingGlam {
+        x: glam::Vec3,
+        y: glam::Mat3,
+        z: f32,
+    }
+
+    let value = UsingGlam {
+        x: glam::Vec3::ZERO,
+        y: glam::Mat3::IDENTITY,
+        z: 0.0,
+    };
+
+    let _ = value.as_std140();
+}
+
+#[test]
 fn two_f32() {
     #[derive(Debug, PartialEq, AsStd140, AsStd430, GlslStruct)]
     struct TwoF32 {

--- a/src/std140/dynamic_uniform.rs
+++ b/src/std140/dynamic_uniform.rs
@@ -1,7 +1,7 @@
 use bytemuck::{Pod, Zeroable};
 
 use crate::internal::max;
-use crate::std140::{AsStd140, Std140};
+use crate::std140::{AlsoAsStd140, AsStd140, Std140};
 
 /// Wrapper type that aligns the inner type to at least 256 bytes.
 ///
@@ -17,6 +17,18 @@ impl<T: AsStd140> AsStd140 for DynamicUniform<T> {
     }
 
     fn from_std140(value: Self::Output) -> Self {
+        DynamicUniform(<T as AsStd140>::from_std140(value.0))
+    }
+}
+
+impl<T: AsStd140> AlsoAsStd140 for DynamicUniform<T> {
+    type Output = DynamicUniformStd140<<T as AsStd140>::Output>;
+
+    fn also_as_std140(&self) -> Self::Output {
+        DynamicUniformStd140(self.0.as_std140())
+    }
+
+    fn also_from_std140(value: Self::Output) -> Self {
         DynamicUniform(<T as AsStd140>::from_std140(value.0))
     }
 }

--- a/src/std140/primitives.rs
+++ b/src/std140/primitives.rs
@@ -1,7 +1,7 @@
 use bytemuck::{Pod, Zeroable};
 
 use crate::glsl::Glsl;
-use crate::std140::{AsStd140, Std140};
+use crate::std140::{AlsoAsStd140, AsStd140, Std140};
 
 macro_rules! primitives {
     (
@@ -60,6 +60,18 @@ macro_rules! vectors {
                 }
 
                 fn from_std140(value: Self) -> Self {
+                    value
+                }
+            }
+
+            impl AlsoAsStd140 for $name {
+                type Output = Self;
+
+                fn also_as_std140(&self) -> Self {
+                    *self
+                }
+
+                fn also_from_std140(value: Self) -> Self {
                     value
                 }
             }
@@ -129,6 +141,18 @@ macro_rules! matrices {
                 }
 
                 fn from_std140(value: Self) -> Self {
+                    value
+                }
+            }
+
+            impl AlsoAsStd140 for $name {
+                type Output = Self;
+
+                fn also_as_std140(&self) -> Self {
+                    *self
+                }
+
+                fn also_from_std140(value: Self) -> Self {
                     value
                 }
             }

--- a/src/std140/traits.rs
+++ b/src/std140/traits.rs
@@ -93,19 +93,26 @@ pub trait AsStd140 {
     fn from_std140(val: Self::Output) -> Self;
 }
 
-impl<T> AsStd140 for T
+#[allow(missing_docs)]
+pub trait AlsoAsStd140 {
+    type Output: Std140;
+    fn also_as_std140(&self) -> Self::Output;
+    fn also_from_std140(val: Self::Output) -> Self;
+}
+
+impl<T> AlsoAsStd140 for T
 where
-    T: mint::IntoMint,
-    T::MintType: AsStd140 + Into<T>,
+    T: mint::IntoMint + Copy,
+    T::MintType: AsStd140 + Into<Self>,
 {
     type Output = <T::MintType as AsStd140>::Output;
 
-    fn as_std140(&self) -> Self::Output {
+    fn also_as_std140(&self) -> Self::Output {
         self.into_mint().as_std140()
     }
 
-    fn from_std140(val: Self::Output) -> Self {
-        T::from_std140(val).into()
+    fn also_from_std140(val: Self::Output) -> Self {
+        T::MintType::from_std140(val).into()
     }
 }
 


### PR DESCRIPTION
This one didn't pan out without implementing `IntoMint` for primitives, but I wanted to open this for visibility.