### PR TITLE
Reduce trait imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased Changes
 * Added correct support for bool-based types. ([#39])
+* Added `.as_bytes()` to generated output types, making it unnecessary to import
+`Std140` or `Std430` in typical concrete code.
 
 [#39]: https://github.com/LPGhatguy/crevice/pull/39
 

--- a/crevice-derive/src/layout.rs
+++ b/crevice-derive/src/layout.rs
@@ -250,6 +250,12 @@ pub fn emit(
         #pad_fn_impls
         #struct_definition
 
+        impl #impl_generics #generated_name #ty_generics #where_clause {
+            pub fn as_bytes(&self) -> &[u8] {
+                <#generated_name #ty_generics as #trait_path>::as_bytes(self)
+            }
+        }
+
         unsafe impl #impl_generics ::crevice::internal::bytemuck::Zeroable for #generated_name #ty_generics #where_clause {}
         unsafe impl #impl_generics ::crevice::internal::bytemuck::Pod for #generated_name #ty_generics #where_clause {}
 

--- a/crevice-derive/src/layout.rs
+++ b/crevice-derive/src/layout.rs
@@ -259,7 +259,7 @@ pub fn emit(
         unsafe impl #impl_generics ::crevice::internal::bytemuck::Zeroable for #generated_name #ty_generics #where_clause {}
         unsafe impl #impl_generics ::crevice::internal::bytemuck::Pod for #generated_name #ty_generics #where_clause {}
 
-        unsafe impl #impl_generics #mod_path::#trait_name for #generated_name #ty_generics #where_clause {
+        unsafe impl #impl_generics #trait_path for #generated_name #ty_generics #where_clause {
             const ALIGNMENT: usize = #struct_alignment;
             const PAD_AT_END: bool = true;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ uniform MAIN {
 ```
 
 ```rust
-use crevice::std140::{AsStd140, Std140};
+use crevice::std140::AsStd140;
 
 #[derive(AsStd140)]
 struct MainUniform {

--- a/src/std140/traits.rs
+++ b/src/std140/traits.rs
@@ -56,7 +56,7 @@ uniform CAMERA {
 ```
 
 ```no_run
-use crevice::std140::{AsStd140, Std140};
+use crevice::std140::AsStd140;
 
 #[derive(AsStd140)]
 struct CameraUniform {

--- a/src/std430/traits.rs
+++ b/src/std430/traits.rs
@@ -56,7 +56,7 @@ uniform CAMERA {
 ```
 
 ```no_run
-use crevice::std430::{AsStd430, Std430};
+use crevice::std430::AsStd430;
 
 #[derive(AsStd430)]
 struct CameraUniform {


### PR DESCRIPTION
This adds an `.as_bytes()` method to generated output types, making it only necessary to import `Std140`/`Std430` if you want to write generic code.

I wasn't sure whether to also add `ALIGNMENT` and `PAD_AT_END` to the generated types.

Also, I've included a minor refactor (using a pre-existing variable with the same contents) as a separate commit so it can be easily omitted if you like.