### PR TITLE
Fix no_std and make CI pipeline more robust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,34 +12,71 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-
     strategy:
+      fail-fast: false
       matrix:
-        rust_version: [stable, "1.52.1"]
+        include:
+          - label: Stable
+            rust_version: stable
+          - label: MSRV
+            rust_version: 1.52.1
+          - label: Stable (All Features)
+            rust_version: stable
+            flags: --all-features
+          - label: Stable (no_std)
+            rust_version: stable
+            flags: --no-default-features
+
+    name: ${{ matrix.label }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - name: Setup Rust toolchain
-      run: rustup default ${{ matrix.rust_version }}
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: ${{ matrix.rust_version }}
+        override: true
+        profile: minimal
 
     - name: Build
-      run: cargo build --verbose
+      run: cargo build --verbose ${{ matrix.flags }}
 
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --verbose ${{ matrix.flags }}
 
-    - name: Rustfmt and Clippy
-      run: |
-        cargo fmt -- --check
-        cargo clippy --all-features
-      if: matrix.rust_version == 'stable'
+  lint:
+    name: Rustfmt and Clippy
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+        components: rustfmt, clippy
+
+    - name: Rustfmt
+      run: cargo fmt -- --check
+
+    - name: Clippy
+      run: cargo clippy --all-features
 
   wgpu-validation:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+        profile: minimal
 
     - name: Run Validation Tests
-      run: cargo test --all-features --no-fail-fast --verbose
+      run: cargo test --package crevice-tests --features wgpu-validation --no-fail-fast --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
             rust_version: 1.52.1
           - label: Stable (All Features)
             rust_version: stable
-            flags: --all-features
+            flags: --features test-all-math-libraries
           - label: Stable (no_std)
             rust_version: stable
             flags: --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ resolver = "2"
 [features]
 default = ["std"]
 std = []
+test-all-math-libraries = ["cgmath", "glam", "nalgebra"]
 
 [workspace]
 members = [".", "crevice-derive", "crevice-tests"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,6 @@ nalgebra = { version = "0.31.0", features = ["mint"], optional = true }
 
 [dev-dependencies]
 insta = "0.16.1"
+
+[package.metadata."docs.rs"]
+all-features = true

--- a/crevice-tests/Cargo.toml
+++ b/crevice-tests/Cargo.toml
@@ -4,10 +4,12 @@ version = "0.1.0"
 edition = "2018"
 
 [features]
-wgpu-validation = ["wgpu", "naga", "futures"]
+default = ["std"]
+std = ["crevice/std"]
+wgpu-validation = ["std", "wgpu", "naga", "futures"]
 
 [dependencies]
-crevice = { path = ".." }
+crevice = { path = "..", default-features = false }
 crevice-derive = { path = "../crevice-derive", features = ["debug-methods"] }
 
 anyhow = "1.0.44"

--- a/crevice-tests/src/lib.rs
+++ b/crevice-tests/src/lib.rs
@@ -15,14 +15,17 @@ fn test_round_trip_primitive<T>(_value: T) {}
 #[macro_use]
 mod util;
 
-use crevice::glsl::GlslStruct;
 use crevice::std140::AsStd140;
 use crevice::std430::AsStd430;
 use mint::{ColumnMatrix2, ColumnMatrix3, ColumnMatrix4, Vector2, Vector3, Vector4};
 
+#[cfg(feature = "wgpu-validation")]
+use crevice::glsl::GlslStruct;
+
 #[test]
 fn two_f32() {
-    #[derive(Debug, PartialEq, AsStd140, AsStd430, GlslStruct)]
+    #[derive(Debug, PartialEq, AsStd140, AsStd430)]
+    #[cfg_attr(feature = "wgpu-validation", derive(GlslStruct))]
     struct TwoF32 {
         x: f32,
         y: f32,
@@ -43,7 +46,8 @@ fn two_f32() {
 
 #[test]
 fn vec2() {
-    #[derive(Debug, PartialEq, AsStd140, AsStd430, GlslStruct)]
+    #[derive(Debug, PartialEq, AsStd140, AsStd430)]
+    #[cfg_attr(feature = "wgpu-validation", derive(GlslStruct))]
     struct UseVec2 {
         one: Vector2<f32>,
     }
@@ -121,7 +125,8 @@ fn mat4_bare() {
 
 #[test]
 fn mat3() {
-    #[derive(Debug, PartialEq, AsStd140, AsStd430, GlslStruct)]
+    #[derive(Debug, PartialEq, AsStd140, AsStd430)]
+    #[cfg_attr(feature = "wgpu-validation", derive(GlslStruct))]
     struct TestData {
         one: ColumnMatrix3<f32>,
     }
@@ -136,7 +141,8 @@ fn mat3() {
 
 #[test]
 fn dvec4() {
-    #[derive(Debug, PartialEq, AsStd140, AsStd430, GlslStruct)]
+    #[derive(Debug, PartialEq, AsStd140, AsStd430)]
+    #[cfg_attr(feature = "wgpu-validation", derive(GlslStruct))]
     struct UsingDVec4 {
         doubles: Vector4<f64>,
     }
@@ -155,7 +161,8 @@ fn dvec4() {
 
 #[test]
 fn four_f64() {
-    #[derive(Debug, PartialEq, AsStd140, AsStd430, GlslStruct)]
+    #[derive(Debug, PartialEq, AsStd140, AsStd430)]
+    #[cfg_attr(feature = "wgpu-validation", derive(GlslStruct))]
     struct FourF64 {
         x: f64,
         y: f64,
@@ -183,7 +190,8 @@ fn four_f64() {
 
 #[test]
 fn two_vec3() {
-    #[derive(Debug, PartialEq, AsStd140, AsStd430, GlslStruct)]
+    #[derive(Debug, PartialEq, AsStd140, AsStd430)]
+    #[cfg_attr(feature = "wgpu-validation", derive(GlslStruct))]
     struct TwoVec3 {
         one: Vector3<f32>,
         two: Vector3<f32>,
@@ -210,7 +218,8 @@ fn two_vec3() {
 
 #[test]
 fn two_vec4() {
-    #[derive(Debug, PartialEq, AsStd140, AsStd430, GlslStruct)]
+    #[derive(Debug, PartialEq, AsStd140, AsStd430)]
+    #[cfg_attr(feature = "wgpu-validation", derive(GlslStruct))]
     struct TwoVec4 {
         one: Vector4<f32>,
         two: Vector4<f32>,
@@ -229,7 +238,8 @@ fn two_vec4() {
 
 #[test]
 fn vec3_then_f32() {
-    #[derive(Debug, PartialEq, AsStd140, AsStd430, GlslStruct)]
+    #[derive(Debug, PartialEq, AsStd140, AsStd430)]
+    #[cfg_attr(feature = "wgpu-validation", derive(GlslStruct))]
     struct Vec3ThenF32 {
         one: Vector3<f32>,
         two: f32,
@@ -248,7 +258,8 @@ fn vec3_then_f32() {
 
 #[test]
 fn mat3_padding() {
-    #[derive(Debug, PartialEq, AsStd140, AsStd430, GlslStruct)]
+    #[derive(Debug, PartialEq, AsStd140, AsStd430)]
+    #[cfg_attr(feature = "wgpu-validation", derive(GlslStruct))]
     struct Mat3Padding {
         // Three rows of 16 bytes (3x f32 + 4 bytes padding)
         one: mint::ColumnMatrix3<f32>,

--- a/src/glsl.rs
+++ b/src/glsl.rs
@@ -6,7 +6,10 @@ should implement [`GlslStruct`], which can be derived.
 
 ## Examples
 Given this struct:
-
+*/
+#![cfg_attr(
+    feature = "std",
+    doc = r##"
 ```rust
 use mint::{ColumnMatrix4, Vector3};
 use crevice::glsl::GlslStruct;
@@ -20,7 +23,9 @@ struct SpotLight {
 
 println!("{}", SpotLight::glsl_definition());
 ```
-
+"##
+)]
+/*!
 The output will be:
 ```glsl
 struct SpotLight {

--- a/src/glsl.rs
+++ b/src/glsl.rs
@@ -52,6 +52,7 @@ pub struct GlslField {
 /// Trait for types that can be represented as a struct in GLSL.
 ///
 /// This trait should not generally be implemented by hand, but can be derived.
+#[cfg(feature = "std")]
 pub unsafe trait GlslStruct: Glsl {
     /// The fields contained in this struct.
     const FIELDS: &'static [GlslField];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,6 +92,10 @@ buffer POINT_LIGHTS {
 } point_lights;
 ```
 
+*/
+#![cfg_attr(
+    feature = "std",
+    doc = r##"
 ```rust
 use crevice::std140::{self, AsStd140};
 
@@ -135,6 +139,9 @@ unmap_gpu_buffer();
 
 # Ok::<(), std::io::Error>(())
 ```
+"##
+)]
+/*!
 
 ## Features
 

--- a/src/std140/dynamic_uniform.rs
+++ b/src/std140/dynamic_uniform.rs
@@ -37,16 +37,18 @@ unsafe impl<T: Pod> Pod for DynamicUniformStd140<T> {}
 mod test {
     use super::*;
 
-    use crate::std140::{self, WriteStd140};
+    use crate::std140::{self, AsStd140};
 
     #[test]
     fn size_is_unchanged() {
-        let dynamic_f32 = DynamicUniform(0.0f32);
-
-        assert_eq!(dynamic_f32.std140_size(), 0.0f32.std140_size());
+        assert_eq!(
+            DynamicUniform::<f32>::std140_size_static(),
+            f32::std140_size_static()
+        );
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn alignment_applies() {
         let mut output = Vec::new();
         let mut writer = std140::Writer::new(&mut output);

--- a/src/std140/dynamic_uniform.rs
+++ b/src/std140/dynamic_uniform.rs
@@ -37,7 +37,7 @@ unsafe impl<T: Pod> Pod for DynamicUniformStd140<T> {}
 mod test {
     use super::*;
 
-    use crate::std140::{self, AsStd140};
+    use crate::std140::AsStd140;
 
     #[test]
     fn size_is_unchanged() {
@@ -50,6 +50,8 @@ mod test {
     #[test]
     #[cfg(feature = "std")]
     fn alignment_applies() {
+        use crate::std140;
+
         let mut output = Vec::new();
         let mut writer = std140::Writer::new(&mut output);
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -38,6 +38,7 @@ fn there_and_back_again() {
 }
 
 #[test]
+#[cfg(feature = "std")]
 fn generate_struct_glsl() {
     #[allow(dead_code)]
     #[derive(GlslStruct)]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,4 +1,3 @@
-use crevice::glsl::GlslStruct;
 use crevice::std140::AsStd140;
 
 #[test]
@@ -40,6 +39,8 @@ fn there_and_back_again() {
 #[test]
 #[cfg(feature = "std")]
 fn generate_struct_glsl() {
+    use crevice::glsl::GlslStruct;
+
     #[allow(dead_code)]
     #[derive(GlslStruct)]
     struct TestGlsl {


### PR DESCRIPTION
Closes #52.

- Fix all existing no_std errors, including tests
- Implement new CI pipeline that tests --all-features and --no-default-features
- Fix crevice-derive implicitly enabling std