### PR TITLE
fix no-std for optional math libraries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,9 @@ crevice-derive = { version = "0.10.0", path = "crevice-derive" }
 bytemuck = "1.12.3"
 mint = "0.5.9"
 
-cgmath = { version = "0.18.0", optional = true }
-glam = { version = "^0.24", features = ["mint"], optional = true }
-nalgebra = { version = "0.32.3", features = ["mint"], optional = true }
+cgmath = { version = "0.18.0", default-features = false, optional = true }
+glam = { version = "^0.24", default-features = false, features = ["mint"], optional = true }
+nalgebra = { version = "0.32.3", default-features = false, features = ["mint"], optional = true }
 
 [dev-dependencies]
 insta = "1.21.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ resolver = "2"
 [features]
 default = ["std"]
 std = []
-test-all-math-libraries = ["cgmath", "glam", "nalgebra"]
+test-all-math-libraries = ["cgmath", "glam", "glam/std", "nalgebra"]
 
 [workspace]
 members = [".", "crevice-derive", "crevice-tests"]


### PR DESCRIPTION
Currently the optional math library dependencies enable the `default-features` for those libraries, causing eg. `glam` to enable the `std` feature, breaking `no-std` environments like `rust-gpu`. This PR disables the by default allowing the end user to enable what they need. 

I'm unsure but this may break dependent projects if those do not explicitly declare a dependency on the math library, but only use it via this crate. For example `glam` will get the `std` feature disabled, but it requires that either `std` or `libm` feature is enabled, otherwise it won't compile. But I'd expect that specific case to basically be non-existent and an easy fix: just declare the math library explicitly.